### PR TITLE
switch string/repr generation around

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -5,6 +5,13 @@ from dateutil import tz as _tz
 
 import time, calendar
 
+#: format string for the arrows,
+#  %H:%M:%S is used instead of %X
+#  to ensure we never encounter AM/PM
+#  even if the locale would mandate it
+FORMAT = "%x %H:%M:%S.%f %z (%Z)"
+
+
 def arrow(date=None, tz=None):
     def _tz_now(tzinfo):
 
@@ -49,14 +56,10 @@ class Arrow(object):
         self._datetime = self._get_datetime(date, self._timezone)
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, self.__str__())
+        return '{0}({1:s})'.format(self.__class__.__name__, self)
 
     def __str__(self):
-
-        time_str = time.strftime('%x %X', self._datetime.timetuple())
-
-        return '{0}.{1} {2}'.format(time_str, self._datetime.microsecond,
-            str(self._timezone))
+        return format(self._datetime, FORMAT)
 
     @staticmethod
     def _get_datetime(dt_expr, time_zone):

--- a/tests/arrow_test.py
+++ b/tests/arrow_test.py
@@ -1,4 +1,5 @@
 from arrow import arrow, Arrow, TimeZone
+from arrow.arrow import FORMAT
 
 from datetime import datetime, timedelta, tzinfo
 from dateutil import tz
@@ -37,17 +38,14 @@ class ArrowTests(BaseArrowTests):
 
     def test_str(self):
 
-        expected = '{0}.{1} +00:00 (UTC)'.format(time.strftime(
-            '%x %X', self.arrow.datetime.timetuple()), self.arrow.datetime.microsecond)
-
-        self.assertEqual(self.arrow.__str__(), expected)
+        expected = format(self.arrow.datetime, FORMAT)
+        self.assertEqual(str(self.arrow), expected)
 
     def test_repr(self):
 
-        expected = 'Arrow({0}.{1} +00:00 (UTC))'.format(time.strftime(
-            '%x %X', self.arrow.datetime.timetuple()), self.arrow.datetime.microsecond)
+        expected = 'Arrow({0:s})'.format(self.arrow)
 
-        self.assertEqual(self.arrow.__repr__(), expected)
+        self.assertEqual(repr(self.arrow), expected)
 
     def test_tz(self):
 


### PR DESCRIPTION
- use a datetime format string instead
- ensure it always uses the 24 hour format
- use the tzinfo of the datetime object to avoid
  patching more than one string together
  (note, this removes the hour separator in the tz display)
- make the format string available to the Tests
- simplify the str tests
