### PR TITLE
Locales in available_locales should be lowercased

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -238,8 +238,8 @@ available_locales = {
     'ru_ru': RussianLocale,
     'el': GreekLocale,
     'zh': ChineseCNLocale,
-    'zh_CN': ChineseCNLocale,
-    'zh_TW': ChineseTWLocale,
+    'zh_cn': ChineseCNLocale,
+    'zh_tw': ChineseTWLocale,
     'ko': KoreanLocale,
-    'ko_KR': KoreanLocale
+    'ko_kr': KoreanLocale
 }


### PR DESCRIPTION
As I've made lowercase call in get_locale_by_name — all locales in dict should be lowercased also. 
I think it's better to handle any case in get_locale_by_name, then force developers to use "only correct case"
