### PR TITLE
Add German localization

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -407,6 +407,44 @@ class UkrainianLocale(BaseRussianLocale):
     day_abbreviations = ['пн', 'вт', 'ср', 'чт', 'пт', 'сб', 'нд']
 
 
+class GermanLocale(Locale):
+
+    names = ['de', 'de_de']
+
+    past = 'vor {0}'
+    future = 'in {0}'
+
+    timeframes = {
+        'now': 'gerade eben',
+        'seconds': 'Sekunden',
+        'minute': 'einer Minute',
+        'minutes': '{0} Minuten',
+        'hour': 'einer Stunde',
+        'hours': '{0} Stunden',
+        'day': 'einem Tag',
+        'days': '{0} Tagen',
+        'month': 'einem Monat',
+        'months': '{0} Monaten',
+        'year': 'einem Jahr',
+        'years': '{0} Jahren',
+    }
+
+    month_names = [
+        '', 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli',
+        'August', 'September', 'Oktober', 'November', 'Dezember'
+    ]
+    month_abbreviations = [
+        '', 'Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep',
+        'Oct', 'Nov', 'Dez'
+    ]
+
+    day_names = [
+        'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag',
+        'Sonntag'
+    ]
+    day_abbreviations = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']
+
+
 def _map_locales():
 
     locales = {}


### PR DESCRIPTION
As the title says. NB it’s de_de, not de_at or de_ch which have slightly different names of months so maybe someone wants to add it.
