### PR TITLE
Added full parse support for microseconds.

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -16,8 +16,11 @@ class ParserError(RuntimeError):
 
 class DateTimeParser(object):
 
-    _FORMAT_RE = re.compile('(YYY?Y?|MM?M?M?|DD?D?D?|HH?|hh?|mm?|ss?|SS?S?|ZZ?|a|A|X)')
+    _FORMAT_RE = re.compile('(YYY?Y?|MM?M?M?|DD?D?D?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?|a|A|X)')
 
+    _ONE_THROUGH_SIX_DIGIT_RE = re.compile('\d{1,6}')
+    _ONE_THROUGH_FIVE_DIGIT_RE = re.compile('\d{1,5}')
+    _ONE_THROUGH_FOUR_DIGIT_RE = re.compile('\d{1,4}')
     _ONE_TWO_OR_THREE_DIGIT_RE = re.compile('\d{1,3}')
     _ONE_OR_TWO_DIGIT_RE = re.compile('\d{1,2}')
     _FOUR_DIGIT_RE = re.compile('\d{4}')
@@ -44,6 +47,10 @@ class DateTimeParser(object):
         'X': re.compile('\d+'),
         'ZZ': _TZ_RE,
         'Z': _TZ_RE,
+        'SSSSSS': _ONE_THROUGH_SIX_DIGIT_RE,
+        'SSSSS': _ONE_THROUGH_FIVE_DIGIT_RE,
+        'SSSS': _ONE_THROUGH_FOUR_DIGIT_RE,
+        'SSS': _ONE_TWO_OR_THREE_DIGIT_RE,
         'SSS': _ONE_TWO_OR_THREE_DIGIT_RE,
         'SS': _ONE_OR_TWO_DIGIT_RE,
         'S': re.compile('\d'),
@@ -107,6 +114,12 @@ class DateTimeParser(object):
         elif token in ['ss', 's']:
             parts['second'] = int(value)
 
+        elif token == 'SSSSSS':
+            parts['microsecond'] = int(value)
+        elif token == 'SSSSS':
+            parts['microsecond'] = int(value) * 10
+        elif token == 'SSSS':
+            parts['microsecond'] = int(value) * 100
         elif token == 'SSS':
             parts['microsecond'] = int(value) * 1000
         elif token == 'SS':

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -109,6 +109,15 @@ class DateTimeParserParseTests(Chai):
         expected = datetime(2013, 1, 1, 12, 30, 45, 999000)
         assertEqual(self.parser.parse('2013-01-01 12:30:45:999', 'YYYY-MM-DD HH:mm:ss:SSS'), expected)
 
+        expected = datetime(2013, 1, 1, 12, 30, 45, 999900)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45:9999', 'YYYY-MM-DD HH:mm:ss:SSSS'), expected)
+
+        expected = datetime(2013, 1, 1, 12, 30, 45, 999990)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45:99999', 'YYYY-MM-DD HH:mm:ss:SSSSS'), expected)
+
+        expected = datetime(2013, 1, 1, 12, 30, 45, 999999)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45:999999', 'YYYY-MM-DD HH:mm:ss:SSSSSS'), expected)
+
     def test_map_lookup_keyerror(self):
 
         with assertRaises(parser.ParserError):
@@ -154,7 +163,8 @@ class DateTimeParserRegexTests(Chai):
 
     def test_format_subsecond(self):
 
-        assertEqual(self.format_regex.findall('SSS-SS-S'), ['SSS', 'SS', 'S'])
+        assertEqual(self.format_regex.findall('SSSSSS-SSSSS-SSSS-SSS-SS-S'),
+                ['SSSSSS', 'SSSSS', 'SSSS', 'SSS', 'SS', 'S'])
 
     def test_format_tz(self):
 


### PR DESCRIPTION
In response to [this](https://github.com/crsmithdev/arrow/issues/37) issue.

Microseconds can now be specified to full resolution (6 places).

Regular expressions and hard-coded if-else token testing have been entered to match style.

Please note that I have not actually run the unit tests because I have python 3 and did not have time at the moment to install a version of Chai that supports it. I _have_ tested parsing by hand, though, and it appears to work.
