### PR TITLE
Fixed plurals of Russian and Ukrainian feminine nouns.

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -174,7 +174,7 @@ class SpanishLocale(Locale):
     names = ['es', 'es_es']
     past = 'hace {0}'
     future = 'en {0}'
-    
+
     timeframes = {
         'now': 'ahora',
         'seconds': 'segundos',
@@ -479,7 +479,7 @@ class RussianLocale(SlavicBaseLocale):
         'now': 'сейчас',
         'seconds': 'несколько секунд',
         'minute': 'минуту',
-        'minutes': ['{0} минута', '{0} минуты', '{0} минут'],
+        'minutes': ['{0} минуту', '{0} минуты', '{0} минут'],
         'hour': 'час',
         'hours': ['{0} час', '{0} часа', '{0} часов'],
         'day': 'день',
@@ -511,9 +511,9 @@ class UkrainianLocale(SlavicBaseLocale):
         'now': 'зараз',
         'seconds': 'кілька секунд',
         'minute': 'хвилину',
-        'minutes': ['{0} хвилина', '{0} хвилини', '{0} хвилин'],
+        'minutes': ['{0} хвилину', '{0} хвилини', '{0} хвилин'],
         'hour': 'годину',
-        'hours': ['{0} година', '{0} години', '{0} годин'],
+        'hours': ['{0} годину', '{0} години', '{0} годин'],
         'day': 'день',
         'days': ['{0} день', '{0} дні', '{0} днів'],
         'month': 'місяць',

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -71,6 +71,16 @@ class RussianLocalesTests(Chai):
         assertEqual(locale._format_timeframe('hours', 22), '22 часа')
         assertEqual(locale._format_timeframe('hours', 25), '25 часов')
 
+        # feminine grammatical gender should be tested separately
+        assertEqual(locale._format_timeframe('minutes', 0), '0 минут')
+        assertEqual(locale._format_timeframe('minutes', 1), '1 минуту')
+        assertEqual(locale._format_timeframe('minutes', 2), '2 минуты')
+        assertEqual(locale._format_timeframe('minutes', 4), '4 минуты')
+        assertEqual(locale._format_timeframe('minutes', 5), '5 минут')
+        assertEqual(locale._format_timeframe('minutes', 21), '21 минуту')
+        assertEqual(locale._format_timeframe('minutes', 22), '22 минуты')
+        assertEqual(locale._format_timeframe('minutes', 25), '25 минут')
+
 
 class PolishLocalesTests(Chai):
 


### PR DESCRIPTION
In Russian and Ukrainian, the word 'month', for example, has masculine
grammatical gender. The word 'minute' in both languages has feminine
grammatical gender, and thus it's inflected for case in a slightly different
way. The word 'hour' is feminine in Ukrainian and masculine in Russian.
A little error in one form of feminine plurals is fixed for Russian and
Ukrainian locales. Tests are edited to reflect this.
