### PR TITLE
Fixing support for unicode strings under Python 2.x in ArrowFactory.get

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 from arrow.arrow import Arrow
 from arrow import parser
+from arrow.util import isstr
 
 from datetime import datetime, tzinfo
 from dateutil import tz as dateutil_tz
@@ -122,7 +123,7 @@ class ArrowFactory(object):
                 return self.type.now(arg)
 
             # (str) -> now, @ tzinfo.
-            elif isinstance(arg, str):
+            elif isstr(arg):
                 dt = parser.DateTimeParser(locale).parse_iso(arg)
                 return self.type.fromdatetime(dt)
 
@@ -140,7 +141,7 @@ class ArrowFactory(object):
                     return self.type.fromdatetime(arg_1, arg_2)
 
                 # (datetime, str) -> fromdatetime @ tzinfo.
-                elif isinstance(arg_2, str):
+                elif isstr(arg_2):
                     _tzinfo = parser.TzinfoParser.parse(arg_2)
                     return self.type.fromdatetime(arg_1, _tzinfo)
 
@@ -149,7 +150,7 @@ class ArrowFactory(object):
                         type(arg_2)))
 
             # (str, format) -> parse.
-            elif isinstance(arg_1, str) and isinstance(arg_2, str):
+            elif isstr(arg_1) and isstr(arg_2):
                 dt = parser.DateTimeParser(locale).parse(args[0], args[1])
                 return self.type.fromdatetime(dt)
 

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -20,4 +20,16 @@ if version < '2.7': # pragma: no cover
 else: # pragma: no cover
     total_seconds = _total_seconds_27
 
-__all__ = ['total_seconds']
+
+# Generate a Python 2.x or 3.x compatible function 
+# for checking if an arg is a string
+try:
+    basestring  # attempt to evaluate basestring
+    def isstr(s):
+        return isinstance(s, basestring)
+except NameError:
+    def isstr(s):
+        return isinstance(s, str)
+
+
+__all__ = ['total_seconds', 'isstr']

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -86,6 +86,12 @@ class GetTests(Chai):
 
         assertEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.tzutc()))
 
+    def test_two_args_unicode_unicode(self):
+
+        result = self.factory.get(u'2013-01-01', u'YYYY-MM-DD')
+
+        assertEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.tzutc()))    
+
     def test_two_args_other(self):
 
         with assertRaises(TypeError):


### PR DESCRIPTION
isinstance(arg, str) will not match unicode strings under Python 2.x

I've added an isstr() function to arrow.util which will correctly match all string types under Python 2.x and 3.x. 

Using six is another possibility. It's not yet a direct dependency in arrow, but it is in dateutil anyway.

See http://stackoverflow.com/questions/11301138/how-to-check-if-variable-is-string-with-python-2-and-3-compatibility for a discussion on the problem.
