### PR TITLE
Changing 'hh' and 'h' format parameters to convert to '12' rather than '0' at midnight

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -56,9 +56,9 @@ class DateTimeFormatter(object):
         if token == 'H':
             return str(dt.hour)
         if token == 'hh':
-            return '{0:02d}'.format(dt.hour if dt.hour < 13 else dt.hour - 12)
+            return '{0:02d}'.format(dt.hour if 0 < dt.hour < 13 else abs(dt.hour - 12))
         if token == 'h':
-            return str(dt.hour if dt.hour < 13 else dt.hour - 12)
+            return str(dt.hour if 0 < dt.hour < 13 else abs(dt.hour - 12))
 
         if token == 'mm':
             return '{0:02d}'.format(dt.minute)

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -54,8 +54,21 @@ class DateTimeFormatterFormatTokenTests(Chai):
         assertEqual(self.formatter._format_token(dt, 'H'), '2')
 
         dt = datetime(2013, 1, 1, 13)
+        assertEqual(self.formatter._format_token(dt, 'HH'), '13')
+        assertEqual(self.formatter._format_token(dt, 'H'), '13')
+
+        dt = datetime(2013, 1, 1, 2)
+        assertEqual(self.formatter._format_token(dt, 'hh'), '02')
+        assertEqual(self.formatter._format_token(dt, 'h'), '2')
+
+        dt = datetime(2013, 1, 1, 13)
         assertEqual(self.formatter._format_token(dt, 'hh'), '01')
         assertEqual(self.formatter._format_token(dt, 'h'), '1')
+
+        # test that 12-hour time converts to '12' at midnight
+        dt = datetime(2013, 1, 1, 0)
+        assertEqual(self.formatter._format_token(dt, 'hh'), '12')
+        assertEqual(self.formatter._format_token(dt, 'h'), '12')
 
     def test_minute(self):
 


### PR DESCRIPTION
The native datetime format option for 12-hour time (%I) converts 12-midnight to '12' rather than '0'

``` python
datetime(2013, 1, 1).strftime('%I:%M %p') -> '12:00 AM'
```

existing Arrow code

``` python
arrow.get(2013, 1, 1).format('hh:mm A') -> '00:00 AM'
```
