### PR TITLE
Fixing parsing of midnight and noon with specified period

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -184,8 +184,10 @@ class DateTimeParser(object):
         am_pm = parts.get('am_pm')
         hour = parts.get('hour', 0)
 
-        if am_pm == 'pm' and hour < 13:
+        if am_pm == 'pm' and hour < 12:
             hour += 12
+        elif am_pm == 'am' and hour == 12:
+            hour = 0
 
         return datetime(year=parts.get('year', 1), month=parts.get('month', 1),
             day=parts.get('day', 1), hour=hour, minute=parts.get('minute', 0),

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -93,6 +93,12 @@ class DateTimeParserParseTests(Chai):
         expected = datetime(1, 1, 1, 1, 0, 0)
         assertEqual(self.parser.parse('1 am', 'H A'), expected)
 
+        expected = datetime(1, 1, 1, 0, 0, 0)
+        assertEqual(self.parser.parse('12 am', 'H A'), expected)
+
+        expected = datetime(1, 1, 1, 12, 0, 0)
+        assertEqual(self.parser.parse('12 pm', 'H A'), expected)
+
     def test_parse_tz(self):
 
         expected = datetime(2013, 1, 1, tzinfo=tz.tzoffset(None, -7 * 3600))


### PR DESCRIPTION
Parsing "12 AM" currently fails with a result of 12:00:00 instead of 00:00:00.
Parsing "12 PM" currently fails with an exception that the hour must be 0..23.

Fixed and added tests.
