### PR TITLE
humanize() should return unicode instead of str

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import calendar
 import inspect

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from chai import Chai
 

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 from chai import Chai
 


### PR DESCRIPTION
It works OK with ascii-locales like the default:

```
>>> print u'Now: {}'.format(arrow.now().humanize())
Now: just now
```

But doesn't work with non-ascii locales like Russian:

```
>>> print u'Now: {}'.format(arrow.now().humanize(locale='ru_RU'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd1 in position 0: ordinal not in range(128)
```
