### PR TITLE
Fixed korean locale words.

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -420,8 +420,8 @@ class KoreanLocale(Locale):
     future = '{0} 후'
 
     timeframes = {
-        'now': '현재',
-        'seconds': '초',
+        'now': '지금',
+        'seconds': '몇초',
         'minute': '일 분',
         'minutes': '{0}분',
         'hour': '1시간',


### PR DESCRIPTION
Two fixes.
1. `현재` -> `지금` for _now_.
   
   I think it is better. `현재` means "current" and `지금` means "right now".
2. `초` -> `몇초` for _seconds_.
   
   If we translate "seconds ago" to korean, it should be "몇초 전" for making sense. ("초": "second", "전": "ago", "몇": "few")
