### PR TITLE
Added __version__ attribute to arrow module

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -4,3 +4,4 @@ from .arrow import Arrow
 from .factory import ArrowFactory
 from .api import get, now, utcnow
 
+__version__ = VERSION = '0.4.2'

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@ try:
 except ImportError:
     from distutils.core import setup
 
+import arrow
+
 setup(
     name='arrow',
-    version='0.4.2',
+    version=arrow.__version__,
     description='Better dates and times for Python',
     url='http://crsmithdev.com/arrow',
     author='Chris Smith',


### PR DESCRIPTION
Added `__version__` (standard attribute) AND `VERSION` as some old tools fallback on the former.
