### PR TITLE
tzinfo: claify tz objects in Docs and add timezone parsing on arrow.get()

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -47,8 +47,10 @@ class Arrow(object):
     _ATTRS_PLURAL = ['{0}s'.format(a) for a in _ATTRS]
 
     def __init__(self, year, month, day, hour=0, minute=0, second=0, microsecond=0,
-        tzinfo=None):
+                 tzinfo=None):
 
+        if util.isstr(tzinfo):
+            tzinfo = parser.TzinfoParser.parse(tzinfo)
         tzinfo = tzinfo or dateutil_tz.tzutc()
 
         self._datetime = datetime(year, month, day, hour, minute, second,
@@ -855,4 +857,3 @@ class Arrow(object):
 
 Arrow.min = Arrow.fromdatetime(datetime.min)
 Arrow.max = Arrow.fromdatetime(datetime.max)
-

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -151,15 +151,9 @@ class ArrowFactory(object):
 
             if isinstance(arg_1, datetime):
 
-                # (datetime, tzinfo) -> fromdatetime @ tzinfo.
-                if isinstance(arg_2, tzinfo):
+                # (datetime, tzinfo) -> fromdatetime @ tzinfo/string.
+                if isinstance(arg_2, tzinfo) or isstr(arg_2):
                     return self.type.fromdatetime(arg_1, arg_2)
-
-                # (datetime, str) -> fromdatetime @ tzinfo.
-                elif isstr(arg_2):
-                    _tzinfo = parser.TzinfoParser.parse(arg_2)
-                    return self.type.fromdatetime(arg_1, _tzinfo)
-
                 else:
                     raise TypeError('Can\'t parse two arguments of types \'datetime\', \'{0}\''.format(
                         type(arg_2)))
@@ -223,4 +217,3 @@ class ArrowFactory(object):
             tz = parser.TzinfoParser.parse(tz)
 
         return self.type.now(tz)
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Python's standard library and some other low-level modules have near-complete da
 
 - Too many modules:  datetime, time, calendar, dateutil, pytz and more
 - Too many types:  date, time, datetime, tzinfo, timedelta, relativedelta, etc.
-- Time zones and timestamp conversions are verbose and unpleasant 
+- Time zones and timestamp conversions are verbose and unpleasant
 - Time zone naievety is the norm
 - Gaps in functionality:  ISO-8601 parsing, timespans, humanization
 
@@ -25,7 +25,7 @@ Python's standard library and some other low-level modules have near-complete da
 Features
 --------
 
-- Fully implemented, drop-in replacement for datetime 
+- Fully implemented, drop-in replacement for datetime
 - Supports Python 2.6, 2.7 and 3.3
 - Time zone-aware & UTC by default
 - Provides super-simple creation options for many common input scenarios
@@ -121,6 +121,7 @@ Use a naive or timezone-aware datetime, or flexibly specify a time zone:
     >>> arrow.get(datetime.now(), 'US/Pacific')
     <Arrow [2013-05-06T21:24:32.736373-07:00]>
 
+    >>> from dateutil impot tz
     >>> arrow.get(datetime.now(), tz.gettz('US/Pacific'))
     <Arrow [2013-05-06T21:24:41.129262-07:00]>
 
@@ -456,4 +457,3 @@ arrow.locale
 
 .. automodule:: arrow.locales
     :members:
-


### PR DESCRIPTION
This fulfils [issue #58](https://github.com/crsmithdev/arrow/issues/58).

In some places you use the `tz` kwarg for objects that may be a string or may be a `tzinfo` object, but it seems a bit unclear if that is the intention, or if it's to avoid collision with the imported `tzinfo` object when an `isinstance` check is raised. I figured for a first crack at it, I'd add the feature without any breaking changes.
