### PR TITLE
Support for 'hh' and 'h' strings

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -38,6 +38,8 @@ class DateTimeParser(object):
         'D': _ONE_OR_TWO_DIGIT_RE,
         'HH': _TWO_DIGIT_RE,
         'H': _ONE_OR_TWO_DIGIT_RE,
+        'hh': _TWO_DIGIT_RE,
+        'h': _ONE_OR_TWO_DIGIT_RE,
         'mm': _TWO_DIGIT_RE,
         'm': _ONE_OR_TWO_DIGIT_RE,
         'ss': _TWO_DIGIT_RE,


### PR DESCRIPTION
Added support for documented ‘hh’ and ‘h’ parse strings, just needed to be added
into the mapper…
