### PR TITLE
Implemented arrow.get(date[, tz]) to fix #99.

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -12,7 +12,7 @@ from arrow.arrow import Arrow
 from arrow import parser
 from arrow.util import isstr
 
-from datetime import datetime, tzinfo
+from datetime import datetime, tzinfo, date
 from dateutil import tz as dateutil_tz
 
 
@@ -84,9 +84,19 @@ class ArrowFactory(object):
             >>> arrow.get(datetime(2013, 5, 5, tzinfo=tz.tzlocal()))
             <Arrow [2013-05-05T00:00:00-07:00]>
 
+        **One** naive ``date``, to get that date in UTC::
+
+            >>> arrow.get(date(2013, 5, 5))
+            <Arrow [2013-05-05T00:00:00+00:00]>
+
         **Two** arguments, a naive or aware ``datetime``, and a timezone expression (as above)::
 
             >>> arrow.get(datetime(2013, 5, 5), 'US/Pacific')
+            <Arrow [2013-05-05T00:00:00-07:00]>
+
+        **Two** arguments, a naive ``date``, and a timezone expression (as above)::
+
+            >>> arrow.get(date(2013, 5, 5), 'US/Pacific')
             <Arrow [2013-05-05T00:00:00-07:00]>
 
         **Two** arguments, both ``str``, to parse the first according to the format of the second::
@@ -133,6 +143,10 @@ class ArrowFactory(object):
             if isinstance(arg, datetime):
                 return self.type.fromdatetime(arg)
 
+            # (date) -> from date.
+            if isinstance(arg, date):
+                return self.type.fromdate(arg)
+
             # (tzinfo) -> now, @ tzinfo.
             elif isinstance(arg, tzinfo):
                 return self.type.now(arg)
@@ -156,6 +170,15 @@ class ArrowFactory(object):
                     return self.type.fromdatetime(arg_1, arg_2)
                 else:
                     raise TypeError('Can\'t parse two arguments of types \'datetime\', \'{0}\''.format(
+                        type(arg_2)))
+
+            # (date, tzinfo/str) -> fromdate @ tzinfo/string.
+            elif isinstance(arg_1, date):
+
+                if isinstance(arg_2, tzinfo) or isstr(arg_2):
+                    return self.type.fromdate(arg_1, tzinfo=arg_2)
+                else:
+                    raise TypeError('Can\'t parse two arguments of types \'date\', \'{0}\''.format(
                         type(arg_2)))
 
             # (str, format) -> parse.

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -1,5 +1,5 @@
 from chai import Chai
-from datetime import datetime
+from datetime import datetime, date
 from dateutil import tz
 import time
 
@@ -53,6 +53,13 @@ class GetTests(Chai):
 
         assertEqual(self.factory.get(dt), dt)
 
+    def test_one_arg_date(self):
+
+        d = date.today()
+        dt = datetime(d.year, d.month, d.day, tzinfo=tz.tzutc())
+
+        assertEqual(self.factory.get(d), dt)
+
     def test_one_arg_tzinfo(self):
 
         expected = datetime.utcnow().replace(tzinfo=tz.tzutc()).astimezone(tz.gettz('US/Pacific'))
@@ -82,10 +89,27 @@ class GetTests(Chai):
 
         assertEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.gettz('US/Pacific')))
 
+    def test_two_args_date_tzinfo(self):
+
+        result = self.factory.get(date(2013, 1, 1), tz.gettz('US/Pacific'))
+
+        assertEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.gettz('US/Pacific')))
+
+    def test_two_args_date_tz_str(self):
+
+        result = self.factory.get(date(2013, 1, 1), 'US/Pacific')
+
+        assertEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.gettz('US/Pacific')))
+
     def test_two_args_datetime_other(self):
 
         with assertRaises(TypeError):
             self.factory.get(datetime.utcnow(), object())
+
+    def test_two_args_date_other(self):
+
+        with assertRaises(TypeError):
+            self.factory.get(date.today(), object())
 
     def test_two_args_str_str(self):
 


### PR DESCRIPTION
Complete with docs and tests, fixes #99 .
