### PR TITLE
Fix for incorrectly inflected word minuta in polish locales

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -572,7 +572,7 @@ class PolishLocale(SlavicBaseLocale):
     timeframes = {
         'now': 'teraz',
         'seconds': 'kilka sekund',
-        'minute': 'minuta',
+        'minute': 'minutę',
         'minutes': ['{0} minut', '{0} minuty', '{0} minut'],
         'hour': 'godzina',
         'hours': ['{0} godzin', '{0} godziny', '{0} godzin'],


### PR DESCRIPTION
Google for verify:
https://www.google.pl/search?q=%22minuta+temu%22 42 900 results
https://www.google.pl/search?q=%22minute+temu%22 1 370 000 results
