### PR TITLE
`setup.py` reads data from arrow/version.py

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -3,5 +3,4 @@
 from .arrow import Arrow
 from .factory import ArrowFactory
 from .api import get, now, utcnow
-
-__version__ = VERSION = '0.4.2'
+from .version import __version__, VERSION

--- a/arrow/version.py
+++ b/arrow/version.py
@@ -1,0 +1,5 @@
+# Store the version here so:
+# 1) we don't load dependencies by storing it in __init__.py
+# 2) we can import it in setup.py for the same reason
+# 3) we can import it into your module module
+__version__ = VERSION = '0.4.2'

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import arrow
+__version__ = "will be set by next line"
+exec(open("arrow/version.py").read())
 
 setup(
     name='arrow',
-    version=arrow.__version__,
+    version=__version__,
     description='Better dates and times for Python',
     url='http://crsmithdev.com/arrow',
     author='Chris Smith',
@@ -20,4 +21,3 @@ setup(
     ],
     test_suite="tests",
 )
-


### PR DESCRIPTION
Former solution was broken. setup.py declared as required python-dateutil,
but before setup() had a chance to install it, there was `import arrow`
which failed in importing from dateutil.

```
    modified:   arrow/__init__.py
    new file:   arrow/version.py
    modified:   setup.py
```
