### PR TITLE
Issue with specify 'X' template and no template at all to arrow.get

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -215,7 +215,8 @@ class DateTimeParser(object):
         timestamp = parts.get('timestamp')
 
         if timestamp:
-            return datetime.fromtimestamp(timestamp)
+            tz_utc = tz.tzutc()
+            return datetime.fromtimestamp(timestamp, tz=tz_utc)
 
         am_pm = parts.get('am_pm')
         hour = parts.get('hour', 0)

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -22,6 +22,13 @@ class GetTests(Chai):
 
         assertDtEqual(self.factory.get(), datetime.utcnow().replace(tzinfo=tz.tzutc()))
 
+    def test_timestamp_one_arg_no_arg(self):
+
+        no_arg = self.factory.get('1406430900').timestamp
+        one_arg = self.factory.get('1406430900', 'X').timestamp
+
+        assertEqual(no_arg, one_arg)
+
     def test_one_arg_non(self):
 
         assertDtEqual(self.factory.get(None), datetime.utcnow().replace(tzinfo=tz.tzutc()))

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -79,8 +79,9 @@ class DateTimeParserParseTests(Chai):
 
     def test_parse_timestamp(self):
 
+        tz_utc = tz.tzutc()
         timestamp = int(time.time())
-        expected = datetime.fromtimestamp(timestamp)
+        expected = datetime.fromtimestamp(timestamp, tz=tz_utc)
         assertEqual(self.parser.parse(str(timestamp), 'X'), expected)
 
     def test_parse_names(self):


### PR DESCRIPTION
One of arrow's features say that it's UTC by default, but I was running into an issue when parsing unix timestamps:

``` python
In [25]: arrow.get('1406430900', 'X').timestamp
Out[25]: 1406416500

In [26]: arrow.get('1406430900').timestamp
Out[26]: 1406430900
```

When specifying the 'X' template arrow was using local time zones, but without the template it was defaulting to the correct behavior (using UTC).
