### PR TITLE
Give format a default parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ And then:
 >>> local.timestamp
 1368303838
 
+>>> local.format()
+'2013-05-11 13:23:58 -07:00'
+
 >>> local.format('YYYY-MM-DD HH:mm:ss ZZ')
 '2013-05-11 13:23:58 -07:00'
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -533,7 +533,7 @@ class Arrow(object):
 
     # string output and formatting.
 
-    def format(self, fmt, locale='en_us'):
+    def format(self, fmt='YYYY-MM-DD HH:mm:ss ZZ', locale='en_us'):
         ''' Returns a string representation of the :class:`Arrow <arrow.arrow.Arrow>` object,
         formatted according to a format string.
 
@@ -549,6 +549,10 @@ class Arrow(object):
 
             >>> arrow.utcnow().format('MMMM DD, YYYY')
             'May 09, 2013'
+
+            >>> arrow.utcnow().format()
+            '2013-05-09 03:56:47 -00:00'
+
         '''
 
         return formatter.DateTimeFormatter(locale).format(self._datetime, fmt)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,9 @@ Quickstart
     >>> local.timestamp
     1368303838
 
+    >>> local.format()
+    '2013-05-11 13:23:58 -07:00'
+
     >>> local.format('YYYY-MM-DD HH:mm:ss ZZ')
     '2013-05-11 13:23:58 -07:00'
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -123,6 +123,12 @@ class ArrowRepresentationTests(Chai):
 
         assertEqual(result, '2013-02-03')
 
+    def test_bare_format(self):
+
+        result = self.arrow.format()
+
+        assertEqual(result, '2013-02-03 12:30:45 -00:00')
+
     def test_format_no_format_string(self):
 
         result = '{0}'.format(self.arrow)


### PR DESCRIPTION
Everything else in arrow has the most sane defaults ever, but getting
a human readable string from format requires a format. Just default to
something.