### PR TITLE
Another way to parse/format using standard timetamp formats (ISO 8601, RFC 2822)

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 from arrow.arrow import Arrow
 from arrow import parser
 from arrow.util import isstr
+from arrow.formats import Format
 
 from datetime import datetime, tzinfo, date
 from dateutil import tz as dateutil_tz
@@ -182,7 +183,7 @@ class ArrowFactory(object):
                         type(arg_2)))
 
             # (str, format) -> parse.
-            elif isstr(arg_1) and (isstr(arg_2) or isinstance(arg_2, list)):
+            elif isstr(arg_1) and (isstr(arg_2) or isinstance(arg_2, list) or isinstance(arg_2, Format)):
                 dt = parser.DateTimeParser(locale).parse(args[0], args[1])
                 return self.type.fromdatetime(dt)
 

--- a/arrow/formats.py
+++ b/arrow/formats.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+'''
+Standard timestamp formats.
+'''
+
+from __future__ import absolute_import
+
+class Format(object):
+    def __init__(self, name=None):
+        self.name = name
+
+iso8601 = Format(name="ISO 8601")
+"""
+ISO-8601 timestamp format
+
+Arrow provides a parser for ISO-8601 timestamps.
+"""
+
+rfc2822 = Format(name="RFC 2822")
+"""
+RFC2822 e-mail timestamp format
+
+Arrow provides a parser and a formatter for RFC 2822 timestamps.
+
+>>> arrow.get('Mon, 30 Sep 2013 15:34:00 -0700', arrow.formats.rfc2822)
+<Arrow [2013-09-30T15:34:00-07:00]>
+"""

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -32,34 +32,8 @@ class DateTimeFormatter(object):
 
         Can't do this with email.utils.formatdate because it can't handle timezones!
         Can't use datetime.datetime.strftime because it won't use the C locale!"""
-        rfc2822_day_names = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
-        rfc2822_month_names = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                               'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-
-        tz_offset = dt.tzinfo.utcoffset(dt)
-        tz_offset_seconds = tz_offset.days * 86400 + tz_offset.seconds
-
-        if tz_offset_seconds < 0:
-          sign = '-'
-          tz_offset_seconds = -tz_offset_seconds
-        else:
-          sign = '+'
-
-        tz_offset_minutes = tz_offset_seconds / 60
-        tz_offset_hours = tz_offset_minutes % 60
-
-        return "%s, %d %s %04d %02d:%02d:%02d %s%02d%02d" % (
-          rfc2822_day_names[dt.weekday()],
-          dt.day,
-          rfc2822_month_names[dt.month - 1],
-          dt.year,
-          dt.hour,
-          dt.minute,
-          dt.second,
-          sign,
-          tz_offset_minutes / 60,
-          tz_offset_minutes % 60
-        )
+        english_formatter = DateTimeFormatter(locale='en_us')
+        return english_formatter.format(dt, 'ddd, D MMM YYYY HH:mm:ss Z')
 
     def _format_token(self, dt, token):
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,7 +137,19 @@ Parse from a string:
 
 Many ISO-8601 compliant strings are recognized and parsed without a format string:
 
+.. code-block:: python
+
     >>> arrow.get('2013-09-30T15:34:00.000-07:00')
+    <Arrow [2013-09-30T15:34:00-07:00]>
+
+Arrow provides parsers for a few standard timestamp formats:
+
+.. code-block:: python
+
+    >>> arrow.get('2013-09-30T15:34:00.000-07:00', arrow.formats.iso8601)
+    <Arrow [2013-09-30T15:34:00-07:00]>
+
+    >>> arrow.get('Mon, 30 Sep 2013 15:34:00 -0700', arrow.formats.rfc2822)
     <Arrow [2013-09-30T15:34:00-07:00]>
 
 Arrow objects can be instantiated directly too, with the same arguments as a datetime:
@@ -220,6 +232,9 @@ Format
 
     >>> arrow.utcnow().format('YYYY-MM-DD HH:mm:ss ZZ')
     '2013-05-07 05:23:16 -00:00'
+
+    >>> arrow.utcnow().format(arrow.formats.rfc2822)
+    'Tue, 7 May 2013 05:23:16 +0000'
 
 Convert
 =======
@@ -429,7 +444,6 @@ Use the following tokens in parsing and formatting:
 |**Timestamp**                   |X             |1381685817                                 |
 +--------------------------------+--------------+-------------------------------------------+
 
-
 ---------
 API Guide
 ---------
@@ -456,4 +470,10 @@ arrow.locale
 ============
 
 .. automodule:: arrow.locales
+    :members:
+
+arrow.formats
+=============
+
+.. automodule:: arrow.formats
     :members:


### PR DESCRIPTION
This should probably use more of arrow's existing parsing and formatting code, and it would be nice if the instances of arrow.formats.Format would contain the parsing/formatting code; then users could define their own Formats.

RFC2822 timestamps need to use English day and month names.
