### PR TITLE
Update layout.html

### DIFF
--- a/docs/_themes/f6/layout.html
+++ b/docs/_themes/f6/layout.html
@@ -14,7 +14,7 @@
 <a href="https://github.com/crsmithdev/arrow"><img style="position: absolute; top: 0; right: 0; border: 0;" 
     src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<h2><a style="font-size: .8em;"href="https://github.com/crsmithdev/arrow">github.com/crsmithdev/arrow</a></h2>
+<h2><a style="font-size: .75em;"href="https://github.com/crsmithdev/arrow">github.com/crsmithdev/arrow</a></h2>
 <iframe src="http://ghbtns.com/github-btn.html?user=crsmithdev&repo=arrow&type=watch&count=true&size=large"
   allowtransparency="true" frameborder="0" scrolling="0" width="150" height="40"></iframe>
 


### PR DESCRIPTION
Make GitHub Stars and the github repository link to fit in one line.

Chrome seems to work with current settings but not Firefox. This fixes it for Firefox too.

![arrow-oneline-pr](https://cloud.githubusercontent.com/assets/553444/3825475/9787aa8e-1d54-11e4-8a8b-aade1e0283cd.png)
