### PR TITLE
Czech localizationCzech localization for Arrow.

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1130,27 +1130,27 @@ class CzechLocale(Locale):
             'past': '{0} sekundami',
             'future': ['{0} sekundy', '{0} sekund']
         },
-        'minute': {'past': 'minutou', 'future': 'minutu'},
+        'minute': {'past': 'minutou', 'future': 'minutu', 'zero': '{0} minut'},
         'minutes': {
             'past': '{0} minutami',
             'future': ['{0} minuty', '{0} minut']
         },
-        'hour': {'past': 'hodinou', 'future': 'hodinu'},
+        'hour': {'past': 'hodinou', 'future': 'hodinu', 'zero': '{0} hodin'},
         'hours': {
             'past': '{0} hodinami',
             'future': ['{0} hodiny', '{0} hodin']
         },
-        'day': {'past': 'dnem', 'future': 'den'},
+        'day': {'past': 'dnem', 'future': 'den', 'zero': '{0} dnů'},
         'days': {
             'past': '{0} dny',
             'future': ['{0} dny', '{0} dnů']
         },
-        'month': {'past': 'měsícem', 'future': 'měsíc'},
+        'month': {'past': 'měsícem', 'future': 'měsíc', 'zero': '{0} měsíců'},
         'months': {
             'past': '{0} měsíci',
             'future': ['{0} měsíce', '{0} měsíců']
         },
-        'year': {'past': 'rokem', 'future': 'rok'},
+        'year': {'past': 'rokem', 'future': 'rok', 'zero': '{0} let'},
         'years': {
             'past': '{0} lety',
             'future': ['{0} roky', '{0} let']
@@ -1174,7 +1174,12 @@ class CzechLocale(Locale):
         '''Czech aware time frame format function, takes into account the differences between past and future forms.'''
         form = self.timeframes[timeframe]
         if isinstance(form, dict):
-            form = form['past'] if delta < 0 else form['future']
+            if delta == 0:
+                form = form['zero'] # And *never* use 0 in the singular!
+            elif delta > 0:
+                form = form['future']
+            else:
+                form = form['past']
         delta = abs(delta)  
 
         if isinstance(form, list):

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -171,3 +171,30 @@ class HindiLocaleTests(Chai):
 
         result = self.locale._format_relative('एक घंट', 'hour', -1)
         assertEqual(result, 'एक घंट पहले')
+
+class CzechLocaleTests(Chai):
+
+    def setUp(self):
+        super(CzechLocaleTests, self).setUp()
+
+        self.locale = locales.CzechLocale()
+
+    def test_format_timeframe(self):
+
+        assertEqual(self.locale._format_timeframe('hours', 2), '2 hodiny')
+        assertEqual(self.locale._format_timeframe('hour', 0), '0 hodin')
+
+    def test_format_relative_now(self):
+
+        result = self.locale._format_relative('Teď', 'now', 0)
+
+        assertEqual(result, 'Teď')
+    def test_format_relative_future(self):
+
+        result = self.locale._format_relative('hodinu', 'hour', 1)
+        assertEqual(result, 'Za hodinu')
+
+    def test_format_relative_past(self):
+
+        result = self.locale._format_relative('hodinou', 'hour', -1)
+        assertEqual(result, 'Před hodinou')


### PR DESCRIPTION
Hello,
this implements the Czech language localization for Arrow using correct rules for past/future human delta representations, of course. Includes names of months/days as weel.
Currently there are no tests, so if they are strictly needed... They can be provided in some next pull request.
