### PR TITLE
Use correct Dutch wording for "hours"

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -523,7 +523,7 @@ class DutchLocale(Locale):
         'minute': 'een minuut',
         'minutes': '{0} minuten',
         'hour': 'een uur',
-        'hours': '{0} uren',
+        'hours': '{0} uur',
         'day': 'een dag',
         'days': '{0} dagen',
         'month': 'een maand',


### PR DESCRIPTION
In Dutch, it is common to use "3 uur" (singular noun) when referring to 3 hours, while we use plural forms for other time frames (days, minutes, seconds, and so on).