### PR TITLE
Added pytz.timezone support.

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -68,7 +68,7 @@ class Arrow(object):
         '''
 
         utc = datetime.utcnow().replace(tzinfo=dateutil_tz.tzutc())
-        dt = utc.astimezone(dateutil_tz.tzlocal() if tzinfo is None else tzinfo)
+        dt = util.astimezone(utc, dateutil_tz.tzlocal() if tzinfo is None else tzinfo)
 
         return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
             dt.microsecond, dt.tzinfo)
@@ -455,10 +455,10 @@ class Arrow(object):
         if not isinstance(tz, tzinfo):
             tz = parser.TzinfoParser.parse(tz)
 
-        dt = self._datetime.astimezone(tz)
+        dt = util.astimezone(self._datetime, tz)
 
         return self.__class__(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
-            dt.microsecond, tz)
+            dt.microsecond, dt.tzinfo)
 
     def span(self, frame):
         ''' Returns two new :class:`Arrow <arrow.arrow.Arrow>` objects, representing the timespan
@@ -577,7 +577,7 @@ class Arrow(object):
 
         if other is None:
             utc = datetime.utcnow().replace(tzinfo=dateutil_tz.tzutc())
-            dt = utc.astimezone(self._datetime.tzinfo)
+            dt = util.astimezone(utc, self._datetime.tzinfo)
 
         elif isinstance(other, Arrow):
             dt = other._datetime
@@ -586,7 +586,7 @@ class Arrow(object):
             if other.tzinfo is None:
                 dt = other.replace(tzinfo=self._datetime.tzinfo)
             else:
-                dt = other.astimezone(self._datetime.tzinfo)
+                dt = util.astimezone(other, self._datetime.tzinfo)
 
         else:
             raise TypeError()
@@ -732,7 +732,7 @@ class Arrow(object):
 
         '''
 
-        return self._datetime.astimezone(tz)
+        return util.astimezone(self._datetime, tz)
 
     def utcoffset(self):
         ''' Returns a ``timedelta`` object representing the whole number of minutes difference from UTC time. '''

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -37,4 +37,22 @@ except NameError: #pragma: no cover
         return isinstance(s, str)
 
 
-__all__ = ['total_seconds', 'isstr']
+def astimezone(date, tz):
+    ''' Returns a ``datetime`` object, adjusted to the specified tzinfo.
+
+        :param date: a ``datetime`` object.
+        :param tz: a ``tzinfo`` object.
+
+    '''
+
+    date = date.astimezone(tz)
+
+    if hasattr(tz, 'normalize'):
+        # A pytz function
+        # See http://pytz.sourceforge.net/#introduction
+        date = tz.normalize(date)
+
+    return date
+
+
+__all__ = ['total_seconds', 'isstr', 'astimezone']

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nose==1.3.0
 nose-cov==1.6
 chai==0.4.0
 sphinx==1.2b1
+pytz==2014.4

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from chai import Chai
-from datetime import timedelta
+from datetime import timedelta, datetime
 import sys
+import pytz
 
 from arrow import util
 
@@ -26,3 +27,19 @@ class UtilTests(Chai):
 
             assertEqual(util._total_seconds_27(td), 30)
 
+    def test_astimezone(self):
+        tz = pytz.timezone("America/Los_Angeles")
+
+        # Test outside of daylight savings time
+        dt = datetime(2014, 1, 1, tzinfo=pytz.utc)
+        dt = util.astimezone(dt, tz)
+        
+        assertFalse(dt.dst())
+        assertEqual(dt.tzinfo._tzinfos, tz._tzinfos)
+
+        # Test inside of daylight savings time
+        dt = datetime(2014, 7, 1, tzinfo=pytz.utc)
+        dt = util.astimezone(dt, tz)
+
+        assertTrue(dt.dst())
+        assertEqual(dt.tzinfo._tzinfos, tz._tzinfos)


### PR DESCRIPTION
This is for issue [#154](https://github.com/crsmithdev/arrow/issues/154) in which arrow did not support pytz.timezone being used.

Let me know if anything else needs to be done so that this can be merged.

I added tests, but always like to verify, just in case:

```
>>> import pytz
>>> import arrow
>>> str(arrow.utcnow().to(pytz.timezone("America/Los_Angeles")).datetime)
'2014-08-17 21:41:00.154590-07:00'
>>> str(arrow.utcnow().to(pytz.timezone("America/Los_Angeles")))
'2014-08-17T21:41:10.141368-07:00'
>>> str(arrow.utcnow().to("America/Los_Angeles").datetime)
'2014-08-17 21:41:57.354034-07:00'
>>> str(arrow.utcnow().to("America/Los_Angeles"))
'2014-08-17T21:42:03.748428-07:00'
>>> str(arrow.util.astimezone(datetime.datetime(2014, 1, 1, tzinfo=pytz.utc), pytz.timezone("America/Los_Angeles")))
'2013-12-31 16:00:00-08:00'
>>> str(arrow.util.astimezone(datetime.datetime(2014, 7, 1, tzinfo=pytz.utc), pytz.timezone("America/Los_Angeles")))
'2014-06-30 17:00:00-07:00'
```
