### PR TITLE
Complete the list of english locales

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -161,7 +161,7 @@ class Locale(object):
 
 class EnglishLocale(Locale):
 
-    names = ['en', 'en_us']
+    names = ['en', 'en_us', 'en_gb', 'en_au', 'en_be', 'en_jp', 'en_za']
 
     past = '{0} ago'
     future = 'in {0}'


### PR DESCRIPTION
English locale is used in more countries than the US.
https://pic.dhe.ibm.com/infocenter/ratdevz/v7r5/index.jsp?topic=%2Fcom.ibm.etools.est.doc%2Ftopics%2Frxmlenaloccp.html

Since this is a library used in multiple projects, I believe it should contain at least the most common locales.
(I encountered a problem using "en_GB" locale before proposing this change)