### PR TITLE
Fix for ISO parsing and formatting for fractional seconds

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -71,15 +71,15 @@ class DateTimeFormatter(object):
             return str(dt.second)
 
         if token == 'SSSSSS':
-            return str(dt.microsecond)
+            return str(dt.microsecond).zfill(6)
         if token == 'SSSSS':
-            return str(int(dt.microsecond / 10))
+            return str(int(dt.microsecond / 10)).zfill(5)
         if token == 'SSSS':
-            return str(int(dt.microsecond / 100))
+            return str(int(dt.microsecond / 100)).zfill(4)
         if token == 'SSS':
-            return str(int(dt.microsecond / 1000))
+            return str(int(dt.microsecond / 1000)).zfill(3)
         if token == 'SS':
-            return str(int(dt.microsecond / 10000))
+            return str(int(dt.microsecond / 10000)).zfill(2)
         if token == 'S':
             return str(int(dt.microsecond / 100000))
 

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -77,7 +77,7 @@ class DateTimeParser(object):
             has_subseconds = '.' in time_parts[0]
 
             if has_subseconds:
-                subseconds_token = 'S' * len(time_parts[0].split('.')[1])
+                subseconds_token = 'S' * len(re.split('\D+', time_parts[0].split('.')[1], 1)[0])
             else:
                 subseconds_token = ''
         else:

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -76,13 +76,18 @@ class DateTimeParser(object):
             has_seconds = time_parts[0].count(':') > 1
             has_subseconds = '.' in time_parts[0]
 
+            if has_subseconds:
+                subseconds_token = 'S' * len(time_parts[0].split('.')[1])
+            else:
+                subseconds_token = ''
         else:
             has_tz = has_seconds = has_subseconds = False
+            subseconds_token = ''
 
         if has_time:
 
             if has_subseconds:
-                formats = ['YYYY-MM-DDTHH:mm:ss.SSSSSS']
+                formats = ['YYYY-MM-DDTHH:mm:ss.%s' % subseconds_token]
             elif has_seconds:
                 formats = ['YYYY-MM-DDTHH:mm:ss']
             else:

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -92,6 +92,14 @@ class DateTimeFormatterFormatTokenTests(Chai):
         assertEqual(self.formatter._format_token(dt, 'SS'), '12')
         assertEqual(self.formatter._format_token(dt, 'S'), '1')
 
+        dt = datetime(2013, 1, 1, 0, 0, 0, 2000)
+        assertEqual(self.formatter._format_token(dt, 'SSSSSS'), '002000')
+        assertEqual(self.formatter._format_token(dt, 'SSSSS'), '00200')
+        assertEqual(self.formatter._format_token(dt, 'SSSS'), '0020')
+        assertEqual(self.formatter._format_token(dt, 'SSS'), '002')
+        assertEqual(self.formatter._format_token(dt, 'SS'), '00')
+        assertEqual(self.formatter._format_token(dt, 'S'), '0')
+
     def test_timestamp(self):
 
         timestamp = time.time()

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -301,54 +301,54 @@ class DateTimeParserISOTests(Chai):
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.7'),
-            datetime(2013, 2, 3, 4, 5, 6, 7)
+            datetime(2013, 2, 3, 4, 5, 6, 700000)
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.78'),
-            datetime(2013, 2, 3, 4, 5, 6, 78)
+            datetime(2013, 2, 3, 4, 5, 6, 780000)
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.789'),
-            datetime(2013, 2, 3, 4, 5, 6, 789)
+            datetime(2013, 2, 3, 4, 5, 6, 789000)
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.7891'),
-            datetime(2013, 2, 3, 4, 5, 6, 7891)
+            datetime(2013, 2, 3, 4, 5, 6, 789100)
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.78912'),
-            datetime(2013, 2, 3, 4, 5, 6, 78912)
+            datetime(2013, 2, 3, 4, 5, 6, 789120)
         )
 
     def test_YYYY_MM_DDTHH_mm_ss_SZ(self):
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.7+01:00'),
-            datetime(2013, 2, 3, 4, 5, 6, 7, tzinfo=tz.tzoffset(None, 3600))
+            datetime(2013, 2, 3, 4, 5, 6, 700000, tzinfo=tz.tzoffset(None, 3600))
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.78+01:00'),
-            datetime(2013, 2, 3, 4, 5, 6, 78, tzinfo=tz.tzoffset(None, 3600))
+            datetime(2013, 2, 3, 4, 5, 6, 780000, tzinfo=tz.tzoffset(None, 3600))
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.789+01:00'),
-            datetime(2013, 2, 3, 4, 5, 6, 789, tzinfo=tz.tzoffset(None, 3600))
+            datetime(2013, 2, 3, 4, 5, 6, 789000, tzinfo=tz.tzoffset(None, 3600))
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.7891+01:00'),
-            datetime(2013, 2, 3, 4, 5, 6, 7891, tzinfo=tz.tzoffset(None, 3600))
+            datetime(2013, 2, 3, 4, 5, 6, 789100, tzinfo=tz.tzoffset(None, 3600))
         )
 
         assertEqual(
             self.parser.parse_iso('2013-02-03T04:05:06.78912+01:00'),
-            datetime(2013, 2, 3, 4, 5, 6, 78912, tzinfo=tz.tzoffset(None, 3600))
+            datetime(2013, 2, 3, 4, 5, 6, 789120, tzinfo=tz.tzoffset(None, 3600))
         )
 
     def test_isoformat(self):

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -351,6 +351,12 @@ class DateTimeParserISOTests(Chai):
             datetime(2013, 2, 3, 4, 5, 6, 789120, tzinfo=tz.tzoffset(None, 3600))
         )
 
+        # Properly parse string with Z timezone
+        assertEqual(
+            self.parser.parse_iso('2013-02-03T04:05:06.78912Z'),
+            datetime(2013, 2, 3, 4, 5, 6, 789120)
+        )
+
     def test_isoformat(self):
 
         dt = datetime.utcnow()


### PR DESCRIPTION
This pull request fixes the bug referenced in #83.

Now, fractional seconds are properly handled and not considered as microseconds:
```python
arrow.get('2013-05-05T12:30:45.2+0030').datetime
datetime.datetime(2013, 5, 5, 12, 30, 45, 200000, tzinfo=tzoffset(None, 1800))

arrow.get('2013-05-05T12:30:45.002+0030').datetime
datetime.datetime(2013, 5, 5, 12, 30, 45, 2000, tzinfo=tzoffset(None, 1800))

arrow.get('2013-05-05T12:30:45.002+0030').format('YYYY-MM-DD HH:mm:ss.SSS ZZ')
'2013-05-05 12:30:45.002 +00:30'

arrow.get('2013-05-05T12:30:45.002+0030').format('YYYY-MM-DD HH:mm:ss.SSSSS ZZ')
'2013-05-05 12:30:45.00200 +00:30'

arrow.get('2013-05-05T12:30:45.002+0030').format('YYYY-MM-DD HH:mm:ss.SSSSSS ZZ')
'2013-05-05 12:30:45.002000 +00:30'
```
