### PR TITLE
fix span_range stability

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -264,7 +264,8 @@ class Arrow(object):
             (<Arrow [2013-05-05T16:00:00+00:00]>, <Arrow [2013-05-05T16:59:59.999999+00:00]>)
 
         '''
-
+        tzinfo = cls._get_tzinfo(start.tzinfo if tz is None else tz)
+        start = cls.fromdate(start, tzinfo).span(frame)[0]
         _range = cls.range(frame, start, end, tz, limit)
         return [r.span(frame) for r in _range]
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -643,6 +643,7 @@ class ArrowSpanRangeTests(Chai):
             (arrow.Arrow(2013, 2, 4), arrow.Arrow(2013, 2, 10, 23, 59, 59, 999999)),
             (arrow.Arrow(2013, 2, 11), arrow.Arrow(2013, 2, 17, 23, 59, 59, 999999)),
             (arrow.Arrow(2013, 2, 18), arrow.Arrow(2013, 2, 24, 23, 59, 59, 999999)),
+            (arrow.Arrow(2013, 2, 25), arrow.Arrow(2013, 3, 3, 23, 59, 59, 999999)),
         ])
 
 


### PR DESCRIPTION
I found the problem in `span_range` function:

```python
In [5]: arrow.Arrow.span_range('week', arrow.Arrow(2014, 9, 10), arrow.Arrow(2014, 9, 16))
Out[5]: 
[(<Arrow [2014-09-08T00:00:00+00:00]>,
  <Arrow [2014-09-14T23:59:59.999999+00:00]>)]
```
but if I shift start_date early, I get the extra week:
```python
In [6]: arrow.Arrow.span_range('week', arrow.Arrow(2014, 9, 9), arrow.Arrow(2014, 9, 16))
Out[6]: 
[(<Arrow [2014-09-08T00:00:00+00:00]>,
  <Arrow [2014-09-14T23:59:59.999999+00:00]>),
 (<Arrow [2014-09-15T00:00:00+00:00]>,
  <Arrow [2014-09-21T23:59:59.999999+00:00]>)]
```
The second behavior, I think, correct: all tests of other time frames include period with end date. So I correct the `span_range` test for week (add absent period) and fix the behavior of `span_range` to pass it.