### PR TITLE
update _map_locales()

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1235,7 +1235,7 @@ def _map_locales():
     for cls_name, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass):
         if issubclass(cls, Locale):
             for name in cls.names:
-                locales[name] = cls  
+                locales[name.lower()] = cls  
 
     return locales
 


### PR DESCRIPTION
The `_map_locales()` function takes the strings from the Locale objects as-is whereas `get_locale(name)` lowers the string before checking the collection. This causes an issue with `ArabicLocale` as `ArabicLocale.names = ['ar', 'ar_EG']` as `get_locale('ar_EG')` raises an exception when it shouldn't.

Edit: rewrote message because it didn't make sense to me after the fact.