### PR TITLE
parse multilingual months, close #61

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-
+from __future__ import unicode_literals
 from datetime import datetime
 from dateutil import tz
 
 import calendar
 import re
 
-from arrow import locales
+from arrow import locales, util
 
 
 class ParserError(RuntimeError):
@@ -30,8 +30,8 @@ class DateTimeParser(object):
     _INPUT_RE_MAP = {
         'YYYY': _FOUR_DIGIT_RE,
         'YY': _TWO_DIGIT_RE,
-        'MMMM': re.compile('({0})'.format('|'.join(calendar.month_name[1:]))),
-        'MMM': re.compile('({0})'.format('|'.join(calendar.month_abbr[1:]))),
+        'MMMM': re.compile('({0})'.format('|'.join(map(util.locale_str, calendar.month_name[1:])))),
+        'MMM': re.compile('({0})'.format('|'.join(map(util.locale_str, calendar.month_abbr[1:])))),
         'MM': _TWO_DIGIT_RE,
         'M': _ONE_OR_TWO_DIGIT_RE,
         'DD': _TWO_DIGIT_RE,
@@ -60,6 +60,13 @@ class DateTimeParser(object):
     def __init__(self, locale='en_us'):
 
         self.locale = locales.get_locale(locale)
+        self._INPUT_RE_MAP = DateTimeParser._INPUT_RE_MAP.copy()
+        month_names = self.locale.month_names[1:]
+        if month_names:
+            self._INPUT_RE_MAP['MMMM'] = re.compile('({0})'.format('|'.join(month_names)))
+        month_abbrs = self.locale.month_abbreviations[1:]
+        if month_abbrs:
+            self._INPUT_RE_MAP['MMM'] = re.compile('({0})'.format('|'.join(month_abbrs)))
 
     def parse_iso(self, string):
 

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-
+import locale
 from datetime import timedelta
 import sys
 
@@ -36,5 +36,16 @@ except NameError: #pragma: no cover
     def isstr(s):
         return isinstance(s, str)
 
+try: # pragma: no cover
+    unicode
+
+    def locale_str(native_str):
+        if not isinstance(native_str, unicode):
+            native_str = native_str.decode(locale.getpreferredencoding(False))
+        return native_str
+except NameError: #pragma: no cover
+    def locale_str(native_str):
+        assert not isinstance(native_str, bytes)
+        return native_str
 
 __all__ = ['total_seconds', 'isstr']

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from chai import Chai
 from datetime import datetime, date
 from dateutil import tz
@@ -135,6 +137,17 @@ class GetTests(Chai):
 
         assertEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.tzutc()))
 
+    def test_localized_months(self):
+        for args, locale, expected in [
+                [('Пятница 24 Октября'.lower(), 'dddd D MMMM'), 'ru',
+                 datetime(1, 10, 24, tzinfo=tz.tzutc())],
+                [('Viernes 24 Octubre', 'dddd D MMMM'), 'es',
+                 datetime(1, 10, 24, tzinfo=tz.tzutc())],
+                [('16/Okt/13 6:53 PM', 'DD/MMM/YY H:mm A'), 'de_DE',
+                 datetime(2013, 10, 16, 18, 53, tzinfo=tz.tzutc())]]:
+            result = self.factory.get(*args, locale=locale)
+            self.assertEqual(result, expected)
+
     def test_two_args_other(self):
 
         with assertRaises(TypeError):
@@ -170,4 +183,3 @@ class NowTests(Chai):
     def test_tz_str(self):
 
         assertDtEqual(self.factory.now('EST'), datetime.now(tz.gettz('EST')))
-

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -50,7 +50,7 @@ class DateTimeParserParseTests(Chai):
 
     def test_parse_unrecognized_token(self):
 
-        mock_input_re_map = mock(parser.DateTimeParser, '_INPUT_RE_MAP')
+        mock_input_re_map = mock(self.parser, '_INPUT_RE_MAP')
 
         expect(mock_input_re_map.__getitem__).args('YYYY').raises(KeyError)
 


### PR DESCRIPTION
Parse month names and abbreviations using parser.locale's lists.