### PR TITLE
Add "for_json" method to support simplejson serialization.

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -792,6 +792,9 @@ class Arrow(object):
 
         return self._datetime.strftime(format)
 
+    def for_json(self):
+        '''Serializes for the ``for_json`` protocol of simplejson.'''
+        return self.isoformat()
 
     # internal tools.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nose==1.3.0
 nose-cov==1.6
 chai==0.4.0
 sphinx==1.2b1
+simplejson==3.6.5

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -6,6 +6,7 @@ from chai import Chai
 
 from datetime import date, datetime, timedelta
 from dateutil import tz
+import simplejson as json
 import calendar
 import pickle
 import time
@@ -370,11 +371,11 @@ class ArrowDatetimeInterfaceTests(Chai):
 
         assertEqual(result, self.arrow._datetime.isoformat())
 
-    def test_for_json(self):
+    def test_simplejson(self):
 
-        result = self.arrow.for_json()
+        result = json.dumps({'v': self.arrow.for_json()}, for_json=True)
 
-        assertEqual(result, self.arrow._datetime.isoformat())
+        assertEqual(json.loads(result)['v'], self.arrow._datetime.isoformat())
 
     def test_ctime(self):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -370,6 +370,12 @@ class ArrowDatetimeInterfaceTests(Chai):
 
         assertEqual(result, self.arrow._datetime.isoformat())
 
+    def test_for_json(self):
+
+        result = self.arrow.for_json()
+
+        assertEqual(result, self.arrow._datetime.isoformat())
+
     def test_ctime(self):
 
         result = self.arrow.ctime()


### PR DESCRIPTION
Hi,

I have added a `for_json` method to the `arrow.Arrow` class then serialize the `Arrow` instances inside a dictionary will be possible.

``` python
>>> import arrow
>>> import simplejson as json
>>> json.dumps({'start': arrow.get(0)}, for_json=True)
'{"start": "1970-01-01T00:00:00+00:00"}'
```

Please review it. Thanks.