### PR TITLE
Raise TypeError on invalid comparison

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -667,6 +667,10 @@ class Arrow(object):
 
     # comparisons
 
+    def _cmperror(self, other):
+        raise TypeError('can\'t compare \'{0}\' to \'{1}\''.format(
+            type(self), type(other)))
+
     def __eq__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
@@ -682,28 +686,28 @@ class Arrow(object):
     def __gt__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            return False
+            self._cmperror(other)
 
         return self._datetime > self._get_datetime(other)
 
     def __ge__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            return False
+            self._cmperror(other)
 
         return self._datetime >= self._get_datetime(other)
 
     def __lt__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            return False
+            self._cmperror(other)
 
         return self._datetime < self._get_datetime(other)
 
     def __le__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            return False
+            self._cmperror(other)
 
         return self._datetime <= self._get_datetime(other)
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -202,13 +202,18 @@ class ArrowComparisonTests(Chai):
 
         assertFalse(self.arrow > self.arrow)
         assertFalse(self.arrow > self.arrow.datetime)
-        assertFalse(self.arrow > 'abc')
+
+        with assertRaises(TypeError):
+            self.arrow > 'abc'
+
         assertTrue(self.arrow < arrow_cmp)
         assertTrue(self.arrow < arrow_cmp.datetime)
 
     def test_ge(self):
 
-        assertFalse(self.arrow >= 'abc')
+        with assertRaises(TypeError):
+            self.arrow >= 'abc'
+
         assertTrue(self.arrow >= self.arrow)
         assertTrue(self.arrow >= self.arrow.datetime)
 
@@ -218,13 +223,18 @@ class ArrowComparisonTests(Chai):
 
         assertFalse(self.arrow < self.arrow)
         assertFalse(self.arrow < self.arrow.datetime)
-        assertFalse(self.arrow < 'abc')
+
+        with assertRaises(TypeError):
+            self.arrow < 'abc'
+
         assertTrue(self.arrow < arrow_cmp)
         assertTrue(self.arrow < arrow_cmp.datetime)
 
     def test_le(self):
 
-        assertFalse(self.arrow <= 'abc')
+        with assertRaises(TypeError):
+            self.arrow <= 'abc'
+
         assertTrue(self.arrow <= self.arrow)
         assertTrue(self.arrow <= self.arrow.datetime)
 


### PR DESCRIPTION
Currently, comparison of `Arrow` to any type except `Arrow` and `datetime.datetime` always gives `False`:
```python
>>> arrow.Arrow(2015, 1, 1) > datetime.date(2015, 1, 2)
False
>>> arrow.Arrow(2015, 1, 1) < datetime.date(2015, 1, 2)
False
```
I think this can be misleading, and suggest raising a `TypeError` instead (this is also what `datetime.datetime` does).
