### PR TITLE
Update humanize local describe for Chinese CN/TW

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -591,16 +591,16 @@ class Arrow(object):
         else:
             raise TypeError()
 
-        delta = int(util.total_seconds(self._datetime - dt))
-        sign = -1 if delta < 0 else 1
-        diff = abs(delta)
+        delta_ = int(util.total_seconds(self._datetime - dt))
+        sign = -1 if delta_ < 0 else 1
+        diff = abs(delta_)
         delta = diff
 
         if diff < 10:
             return locale.describe('now')
 
         if diff < 45:
-            return locale.describe('seconds', sign)
+            return locale.describe('seconds', delta_)
 
         elif diff < 90:
             return locale.describe('minute', sign)

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -425,7 +425,7 @@ class ChineseCNLocale(Locale):
 
     timeframes = {
         'now': '刚才',
-        'seconds': '秒',
+        'seconds': '{0}秒',
         'minute': '1分钟',
         'minutes': '{0}分钟',
         'hour': '1小时',
@@ -456,7 +456,7 @@ class ChineseTWLocale(Locale):
 
     timeframes = {
         'now': '剛才',
-        'seconds': '秒',
+        'seconds': '{0}秒',
         'minute': '1分鐘',
         'minutes': '{0}分鐘',
         'hour': '1小時',
@@ -806,7 +806,7 @@ class NewNorwegianLocale(Locale):
 
 class PortugueseLocale(Locale):
     names = ['pt', 'pt_pt']
-    
+
     past = 'há {0}'
     future = 'em {0}'
 
@@ -833,11 +833,11 @@ class PortugueseLocale(Locale):
     day_names = ['', 'Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira',
         'Sábado', 'Domingo']
     day_abbreviations = ['', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab', 'Dom']
-    
-    
+
+
 class BrazilianPortugueseLocale(PortugueseLocale):
     names = ['pt_br']
-    
+
     past = 'fazem {0}'
 
 
@@ -1180,7 +1180,7 @@ class CzechLocale(Locale):
                 form = form['future']
             else:
                 form = form['past']
-        delta = abs(delta)  
+        delta = abs(delta)
 
         if isinstance(form, list):
             if 2 <= delta % 10 <= 4 and (delta % 100 < 10 or delta % 100 >= 20):
@@ -1235,7 +1235,7 @@ def _map_locales():
     for cls_name, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass):
         if issubclass(cls, Locale):
             for name in cls.names:
-                locales[name] = cls  
+                locales[name] = cls
 
     return locales
 


### PR DESCRIPTION
Update humanize local describe for Chinese CN/TW, "秒前" is not a correct Chinese grammar
