### PR TITLE
Parse lower-cased 'h'

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -175,7 +175,7 @@ class DateTimeParser(object):
         elif token in ['DD', 'D']:
             parts['day'] = int(value)
 
-        elif token in ['HH', 'H', 'hh', 'h']:
+        elif token.upper() in ['HH', 'H']:
             parts['hour'] = int(value)
 
         elif token in ['mm', 'm']:

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -175,7 +175,7 @@ class DateTimeParser(object):
         elif token in ['DD', 'D']:
             parts['day'] = int(value)
 
-        elif token in ['HH', 'H']:
+        elif token in ['HH', 'H', 'hh', 'h']:
             parts['hour'] = int(value)
 
         elif token in ['mm', 'm']:

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -95,15 +95,19 @@ class DateTimeParserParseTests(Chai):
 
         expected = datetime(1, 1, 1, 13, 0, 0)
         assertEqual(self.parser.parse('1 pm', 'H a'), expected)
+        assertEqual(self.parser.parse('1 pm', 'h a'), expected)
 
         expected = datetime(1, 1, 1, 1, 0, 0)
         assertEqual(self.parser.parse('1 am', 'H A'), expected)
+        assertEqual(self.parser.parse('1 am', 'h A'), expected)
 
         expected = datetime(1, 1, 1, 0, 0, 0)
         assertEqual(self.parser.parse('12 am', 'H A'), expected)
+        assertEqual(self.parser.parse('12 am', 'h A'), expected)
 
         expected = datetime(1, 1, 1, 12, 0, 0)
         assertEqual(self.parser.parse('12 pm', 'H A'), expected)
+        assertEqual(self.parser.parse('12 pm', 'h A'), expected)
 
     def test_parse_tz(self):
 


### PR DESCRIPTION
It appears the documented 'h' and 'hh' tokens are not currently working, the following Pull Request is an attempt at fixing that.

Before the fix:

```python
>>> arrow.get("5 PM", "h A")
<Arrow [0001-01-01T12:00:00+00:00]>
```

After the fix:
```python
>>> arrow.get("5 PM", "h A")
<Arrow [0001-01-01T17:00:00+00:00]>
```
