### PR TITLE
Add Hebrew Locale

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1265,6 +1265,56 @@ class MacedonianLocale(Locale):
     day_abbreviations = ['', 'Пон.', ' Вт.', ' Сре.', ' Чет.', ' Пет.', ' Саб.', ' Нед.']
 
 
+class HebrewLocale(Locale):
+
+    names = ['he', 'he_IL']
+
+    past = 'לפני {0}'
+    future = 'בעוד {0}'
+
+    timeframes = {
+        'now': 'הרגע',
+        'seconds': 'שניות',
+        'minute': 'דקה',
+        'minutes': '{0} דקות',
+        'hour': 'שעה',
+        'hours': '{0} שעות',
+        '2-hours': 'שעתיים',
+        'day': 'יום',
+        'days': '{0} ימים',
+        '2-days': 'יומיים',
+        'month': 'חודש',
+        'months': '{0} חודשים',
+        '2-months': 'חודשיים',
+        'year': 'שנה',
+        'years': '{0} שנים',
+        '2-years': 'שנתיים',
+    }
+
+    meridians = {
+        'am': 'לפנ"צ',
+        'pm': 'אחר"צ',
+        'AM': 'לפני הצהריים',
+        'PM': 'אחרי הצהריים',
+    }
+
+    month_names = ['', 'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי',
+                   'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר']
+    month_abbreviations = ['', 'ינו׳', 'פבר׳', 'מרץ', 'אפר׳', 'מאי', 'יוני', 'יולי', 'אוג׳',
+                           'ספט׳', 'אוק׳', 'נוב׳', 'דצמ׳']
+
+    day_names = ['', 'שני', 'שלישי', 'רביעי', 'חמישי', 'שישי', 'שבת', 'ראשון']
+    day_abbreviations = ['', 'ב׳', 'ג׳', 'ד׳', 'ה׳', 'ו׳', 'ש׳', 'א׳']
+
+    def _format_timeframe(self, timeframe, delta):
+        '''Hebrew couple of <timeframe> aware'''
+        couple = '2-{0}'.format(timeframe)
+        if abs(delta) == 2 and couple in self.timeframes:
+            return self.timeframes[couple].format(abs(delta))
+        else:
+            return self.timeframes[timeframe].format(abs(delta))
+
+
 def _map_locales():
 
     locales = {}

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -198,3 +198,19 @@ class CzechLocaleTests(Chai):
 
         result = self.locale._format_relative('hodinou', 'hour', -1)
         assertEqual(result, 'Před hodinou')
+
+
+class HebrewLocaleTests(Chai):
+
+    def test_couple_of_timeframe(self):
+        locale = locales.HebrewLocale()
+
+        assertEqual(locale._format_timeframe('hours', 2), 'שעתיים')
+        assertEqual(locale._format_timeframe('months', 2), 'חודשיים')
+        assertEqual(locale._format_timeframe('days', 2), 'יומיים')
+        assertEqual(locale._format_timeframe('years', 2), 'שנתיים')
+
+        assertEqual(locale._format_timeframe('hours', 3), '3 שעות')
+        assertEqual(locale._format_timeframe('months', 4), '4 חודשים')
+        assertEqual(locale._format_timeframe('days', 3), '3 ימים')
+        assertEqual(locale._format_timeframe('years', 5), '5 שנים')


### PR DESCRIPTION
includes special support for "couple of years/months/days/hours" as they are different words in Hebrew.