### PR TITLE
Case insensitive month match

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -30,8 +30,8 @@ class DateTimeParser(object):
     _INPUT_RE_MAP = {
         'YYYY': _FOUR_DIGIT_RE,
         'YY': _TWO_DIGIT_RE,
-        'MMMM': re.compile('({0})'.format('|'.join(calendar.month_name[1:]))),
-        'MMM': re.compile('({0})'.format('|'.join(calendar.month_abbr[1:]))),
+        'MMMM': re.compile('({0})'.format('|'.join(calendar.month_name[1:])), re.IGNORECASE),
+        'MMM': re.compile('({0})'.format('|'.join(calendar.month_abbr[1:])), re.IGNORECASE),
         'MM': _TWO_DIGIT_RE,
         'M': _ONE_OR_TWO_DIGIT_RE,
         'DD': _TWO_DIGIT_RE,
@@ -164,7 +164,8 @@ class DateTimeParser(object):
             parts['year'] = 1900 + value if value > 68 else 2000 + value
 
         elif token in ['MMMM', 'MMM']:
-            parts['month'] = self.locale.month_number(value)
+            parts['month'] = self.locale.month_number(value.capitalize())
+
         elif token in ['MM', 'M']:
             parts['month'] = int(value)
 

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -398,3 +398,53 @@ class TzinfoParserTests(Chai):
 
         with assertRaises(parser.ParserError):
             self.parser.parse('fail')
+
+
+class DateTimeParserMonthNameTests(Chai):
+
+    def setUp(self):
+        super(DateTimeParserMonthNameTests, self).setUp()
+
+        self.parser = parser.DateTimeParser('en_us')
+
+    def test_shortmonth_capitalized(self):
+
+        assertEqual(
+            self.parser.parse('2013-Jan-01', 'YYYY-MMM-DD'),
+            datetime(2013, 1, 1)
+        )
+
+    def test_shortmonth_allupper(self):
+
+        assertEqual(
+            self.parser.parse('2013-JAN-01', 'YYYY-MMM-DD'),
+            datetime(2013, 1, 1)
+        )
+
+    def test_shortmonth_alllower(self):
+
+        assertEqual(
+            self.parser.parse('2013-jan-01', 'YYYY-MMM-DD'),
+            datetime(2013, 1, 1)
+        )
+
+    def test_month_capitalized(self):
+
+        assertEqual(
+            self.parser.parse('2013-January-01', 'YYYY-MMMM-DD'),
+            datetime(2013, 1, 1)
+        )
+
+    def test_month_allupper(self):
+
+        assertEqual(
+            self.parser.parse('2013-JANUARY-01', 'YYYY-MMMM-DD'),
+            datetime(2013, 1, 1)
+        )
+
+    def test_month_alllower(self):
+
+        assertEqual(
+            self.parser.parse('2013-january-01', 'YYYY-MMMM-DD'),
+            datetime(2013, 1, 1)
+        )


### PR DESCRIPTION
arrow.get() requires an exact string match for the month name and month abbreviation tokens (MMM and MMMM).  Thus Feb matches MMM but feb and FEB do not.  This is straightforward to work around in calling code, but seemed as though it might be common enough to warrent a patch.

Note that this does not work with non english locales (due to using calendar to build the regex rather than the parser locale) but as far as I can tell this isn't a regression.