### PR TITLE
Be explicit about encoding when reading in README.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     name='arrow',
     version=grep('__version__'),
     description='Better dates and times for Python',
-    long_description=open('README.rst').read(),
+    long_description=read(fpath('README.rst')),
     url='https://github.com/crsmithdev/arrow/',
     author='Chris Smith',
     author_email="crsmithdev@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import codecs
 import os.path
 import re
 
@@ -13,7 +14,7 @@ def fpath(name):
 
 
 def read(fname):
-    return open(fpath(fname)).read()
+    return codecs.open(fpath(fname), encoding='utf-8').read()
 
 
 def grep(attrname):


### PR DESCRIPTION
I hit an issue when trying to install arrow with python3.  It defaulted to trying the interpret the README via an ascii encoding, when it's really utf-8 encoded.  This approach should work on both python2 and python3.