### PR TITLE
Add count argument to span method

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -460,11 +460,12 @@ class Arrow(object):
         return self.__class__(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
             dt.microsecond, tz)
 
-    def span(self, frame):
+    def span(self, frame, count=1):
         ''' Returns two new :class:`Arrow <arrow.arrow.Arrow>` objects, representing the timespan
         of the :class:`Arrow <arrow.arrow.Arrow>` object in a given timeframe.
 
         :param frame: the timeframe.  Can be any ``datetime`` property (day, hour, minute...).
+        :param count: (optional) the number of frames to span.
 
         Usage::
 
@@ -476,6 +477,9 @@ class Arrow(object):
 
             >>> arrow.utcnow().span('day')
             (<Arrow [2013-05-09T00:00:00+00:00]>, <Arrow [2013-05-09T23:59:59.999999+00:00]>)
+
+            >>> arrow.utcnow().span('day', count=2)
+            (<Arrow [2013-05-09T00:00:00+00:00]>, <Arrow [2013-05-10T23:59:59.999999+00:00]>)
 
         '''
 
@@ -494,7 +498,7 @@ class Arrow(object):
         if frame_absolute == 'week':
             floor = floor + relativedelta(days=-(self.isoweekday() - 1))
 
-        ceil = floor + relativedelta(**{frame_relative: 1}) + relativedelta(microseconds=-1)
+        ceil = floor + relativedelta(**{frame_relative: count}) + relativedelta(microseconds=-1)
 
         return floor, ceil
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -783,6 +783,13 @@ class ArrowSpanTests(Chai):
         assertEqual(floor, datetime(2013, 1, 1, tzinfo=tz.tzutc()))
         assertEqual(ceil, datetime(2013, 12, 31, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
 
+    def test_span_year_count(self):
+
+        floor, ceil = self.arrow.span('year', 2)
+
+        assertEqual(floor, datetime(2013, 1, 1, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2014, 12, 31, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
     def test_span_month(self):
 
         floor, ceil = self.arrow.span('month')


### PR DESCRIPTION
I found myself wanting a span of N years in some code I was writing. I was able to do this with:
```python
end = start.replace(years=+num_years).ceil('year')
```
...but I was surprised that I couldn't just do:
```python
start, end = start.span('year', num_years)
```
This patch adds a count argument to the span method so that the above example does the right thing. It turned out to be trivial to implement and I made the argument optional and defaulting to 1 so that it's backwards-compatible.

I added a single unit test, I'm not sure how thorough you like to be here.