### PR TITLE
Spanish locale: `Miercoles` should have acute accent

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -250,7 +250,7 @@ class SpanishLocale(Locale):
     month_abbreviations = ['', 'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago',
         'Sep', 'Oct', 'Nov', 'Dic']
 
-    day_names = ['', 'Lunes', 'Martes', 'Miercoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo']
+    day_names = ['', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo']
     day_abbreviations = ['', 'Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab', 'Dom']
 
 


### PR DESCRIPTION
This is following the rules of the Real Academia de la Lengua Española.