### PR TITLE
Modify tzinfo parameter in `get` api,

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -124,9 +124,12 @@ class ArrowFactory(object):
 
         arg_count = len(args)
         locale = kwargs.get('locale', 'en_us')
+        tz = kwargs.get('tzinfo', None)
 
         # () -> now, @ utc.
         if arg_count == 0:
+            if isinstance(tz, tzinfo):
+                return self.type.now(tz)
             return self.type.utcnow()
 
         if arg_count == 1:
@@ -195,7 +198,7 @@ class ArrowFactory(object):
             # (str, format) -> parse.
             elif isstr(arg_1) and (isstr(arg_2) or isinstance(arg_2, list)):
                 dt = parser.DateTimeParser(locale).parse(args[0], args[1])
-                return self.type.fromdatetime(dt)
+                return self.type.fromdatetime(dt, tzinfo=tz)
 
             else:
                 raise TypeError('Can\'t parse two arguments of types \'{0}\', \'{1}\''.format(

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -146,6 +146,14 @@ class GetTests(Chai):
         with assertRaises(TypeError):
             self.factory.get(object(), object())
 
+    def test_three_args_with_tzinfo(self):
+
+        timefmt = 'YYYYMMDD'
+        d = '20150514'
+
+        assertEqual(self.factory.get(d, timefmt, tzinfo=tz.tzlocal()),
+                    datetime(2015, 5, 14, tzinfo=tz.tzlocal()))
+
     def test_three_args(self):
 
         assertEqual(self.factory.get(2013, 1, 1), datetime(2013, 1, 1, tzinfo=tz.tzutc()))


### PR DESCRIPTION
It now can support (str, format, tzinfo=tzinfo())

```
In [1]: import arrow

In [2]: from dateutil import tz

In [3]: timefmt = 'YYYYMMDD HH:mm:ss.SSS'

In [4]: d = '20150514 03:08:22.992'

In [5]: arrow.get(d, timefmt)
Out[5]: <Arrow [2015-05-14T03:08:22.992000+00:00]>

In [6]: arrow.get(d, timefmt, tzinfo=tz.tzlocal())
Out[6]: <Arrow [2015-05-14T03:08:22.992000+08:00]>
```
