### PR TITLE
READY FOR REVIEW - Fix #219. Add minimal support for fractional seconds longer than six digits.

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -77,7 +77,7 @@ class DateTimeParser(object):
             has_subseconds = '.' in time_parts[0]
 
             if has_subseconds:
-                subseconds_token = 'S' * len(re.split('\D+', time_parts[0].split('.')[1], 1)[0])
+                subseconds_token = 'S' * min(len(re.split('\D+', time_parts[0].split('.')[1], 1)[0]), 6)
                 formats = ['YYYY-MM-DDTHH:mm:ss.%s' % subseconds_token]
             elif has_seconds:
                 formats = ['YYYY-MM-DDTHH:mm:ss']

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -117,22 +117,40 @@ class DateTimeParserParseTests(Chai):
     def test_parse_subsecond(self):
 
         expected = datetime(2013, 1, 1, 12, 30, 45, 900000)
-        assertEqual(self.parser.parse('2013-01-01 12:30:45:9', 'YYYY-MM-DD HH:mm:ss:S'), expected)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.9', 'YYYY-MM-DD HH:mm:ss.S'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.9'), expected)
 
-        expected = datetime(2013, 1, 1, 12, 30, 45, 990000)
-        assertEqual(self.parser.parse('2013-01-01 12:30:45:99', 'YYYY-MM-DD HH:mm:ss:SS'), expected)
+        expected = datetime(2013, 1, 1, 12, 30, 45, 980000)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.98', 'YYYY-MM-DD HH:mm:ss.SS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.98'), expected)
 
-        expected = datetime(2013, 1, 1, 12, 30, 45, 999000)
-        assertEqual(self.parser.parse('2013-01-01 12:30:45:999', 'YYYY-MM-DD HH:mm:ss:SSS'), expected)
+        expected = datetime(2013, 1, 1, 12, 30, 45, 987000)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.987', 'YYYY-MM-DD HH:mm:ss.SSS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.987'), expected)
 
-        expected = datetime(2013, 1, 1, 12, 30, 45, 999900)
-        assertEqual(self.parser.parse('2013-01-01 12:30:45:9999', 'YYYY-MM-DD HH:mm:ss:SSSS'), expected)
+        expected = datetime(2013, 1, 1, 12, 30, 45, 987600)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.9876', 'YYYY-MM-DD HH:mm:ss.SSSS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.9876'), expected)
 
-        expected = datetime(2013, 1, 1, 12, 30, 45, 999990)
-        assertEqual(self.parser.parse('2013-01-01 12:30:45:99999', 'YYYY-MM-DD HH:mm:ss:SSSSS'), expected)
+        expected = datetime(2013, 1, 1, 12, 30, 45, 987650)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.98765', 'YYYY-MM-DD HH:mm:ss.SSSSS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.98765'), expected)
 
-        expected = datetime(2013, 1, 1, 12, 30, 45, 999999)
-        assertEqual(self.parser.parse('2013-01-01 12:30:45:999999', 'YYYY-MM-DD HH:mm:ss:SSSSSS'), expected)
+        expected = datetime(2013, 1, 1, 12, 30, 45, 987654)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.987654', 'YYYY-MM-DD HH:mm:ss.SSSSSS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.987654'), expected)
+
+        expected = datetime(2013, 1, 1, 12, 30, 45, 987654)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.9876543', 'YYYY-MM-DD HH:mm:ss.SSSSSS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.9876543'), expected)
+
+        expected = datetime(2013, 1, 1, 12, 30, 45, 987654)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.98765432', 'YYYY-MM-DD HH:mm:ss.SSSSSS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.98765432'), expected)
+
+        expected = datetime(2013, 1, 1, 12, 30, 45, 987654)
+        assertEqual(self.parser.parse('2013-01-01 12:30:45.987654321', 'YYYY-MM-DD HH:mm:ss.SSSSSS'), expected)
+        assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.987654321'), expected)
 
     def test_map_lookup_keyerror(self):
 


### PR DESCRIPTION
Note that this PR merely corrects the narrow issue observed in #219. Many of the more esoteric features of ISO 8601 are still absent. For example, [fractional portions are contemplated for *any time member*](https://en.wikipedia.org/wiki/ISO_8601#Times). Also, the fractional portion delimiter can be a period (`.`) or a comma (`,`). In other words, the following should be equivalent:

* `2015-05-01T12.2525Z`
* `2015-05-01T12:15,15Z` (note the comma)
* `2015-05-01T12:15:09Z`

Addressing *those* would require a significant change to `parse_iso()`. To be fair, I don't know if *any* library is actually fully ISO 8601 compliant. `dateutils` for example only supports fractional minutes with the period delimiter:

```py
>>> from dateutil.parser import parse
>>> parse('2015-05-01T12:34:56,123Z') # no support for commas
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../site-packages/dateutil/parser.py", line 1008, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File ".../site-packages/dateutil/parser.py", line 395, in parse
    raise ValueError("Unknown string format")
ValueError: Unknown string format
>>> parse('2015-05-01T12:34.5Z') # fractional minutes work
datetime.datetime(2015, 5, 1, 12, 34, 30, tzinfo=tzutc())
>>> parse('2015-05-01T12.5Z') # but not fractional hours
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../site-packages/dateutil/parser.py", line 1008, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File ".../site-packages/dateutil/parser.py", line 395, in parse
    raise ValueError("Unknown string format")
ValueError: Unknown string format
```

I can file a separate issue for this if desired, but I thought I'd mention it here first.