### PR TITLE
humanize for time duration

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -562,13 +562,13 @@ class Arrow(object):
         return formatter.DateTimeFormatter(locale).format(self._datetime, fmt)
 
 
-    def humanize(self, other=None, locale='en_us'):
+    def humanize(self, other=None, locale='en_us', only_distance=False):
         ''' Returns a localized, humanized representation of a relative difference in time.
 
         :param other: (optional) an :class:`Arrow <arrow.arrow.Arrow>` or ``datetime`` object.
             Defaults to now in the current :class:`Arrow <arrow.arrow.Arrow>` object's timezone.
         :param locale: (optional) a ``str`` specifying a locale.  Defaults to 'en_us'.
-
+        :param only_difference: (optional) returns only time difference eg: "11 seconds" without "in" or "ago" part.
         Usage::
 
             >>> earlier = arrow.utcnow().replace(hours=-2)
@@ -605,43 +605,43 @@ class Arrow(object):
         delta = diff
 
         if diff < 10:
-            return locale.describe('now')
+            return locale.describe('now', only_distance=only_distance)
 
         if diff < 45:
-            return locale.describe('seconds', sign)
+            return locale.describe('seconds', sign, only_distance=only_distance)
 
         elif diff < 90:
-            return locale.describe('minute', sign)
+            return locale.describe('minute', sign, only_distance=only_distance)
         elif diff < 2700:
             minutes = sign * int(max(delta / 60, 2))
-            return locale.describe('minutes', minutes)
+            return locale.describe('minutes', minutes, only_distance=only_distance)
 
         elif diff < 5400:
-            return locale.describe('hour', sign)
+            return locale.describe('hour', sign, only_distance=only_distance)
         elif diff < 79200:
             hours = sign * int(max(delta / 3600, 2))
-            return locale.describe('hours', hours)
+            return locale.describe('hours', hours, only_distance=only_distance)
 
         elif diff < 129600:
-            return locale.describe('day', sign)
+            return locale.describe('day', sign, only_distance=only_distance)
         elif diff < 2160000:
             days = sign * int(max(delta / 86400, 2))
-            return locale.describe('days', days)
+            return locale.describe('days', days, only_distance=only_distance)
 
         elif diff < 3888000:
-            return locale.describe('month', sign)
+            return locale.describe('month', sign, only_distance=only_distance)
         elif diff < 29808000:
             self_months = self._datetime.year * 12 + self._datetime.month
             other_months = dt.year * 12 + dt.month
             months = sign * abs(other_months - self_months)
 
-            return locale.describe('months', months)
+            return locale.describe('months', months, only_distance=only_distance)
 
         elif diff < 47260800:
-            return locale.describe('year', sign)
+            return locale.describe('year', sign, only_distance=only_distance)
         else:
             years = sign * int(max(delta / 31536000, 2))
-            return locale.describe('years', years)
+            return locale.describe('years', years, only_distance=only_distance)
 
 
     # math

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -65,16 +65,17 @@ class Locale(object):
 
         self._month_name_to_ordinal = None
 
-    def describe(self, timeframe, delta=0):
+    def describe(self, timeframe, delta=0, only_distance=False):
         ''' Describes a delta within a timeframe in plain language.
 
         :param timeframe: a string representing a timeframe.
         :param delta: a quantity representing a delta in a timeframe.
-
+        :param only_distance: return only distance eg: "11 seconds" without "in" or "ago" keywords
         '''
 
         humanized = self._format_timeframe(timeframe, delta)
-        humanized = self._format_relative(humanized, timeframe, delta)
+        if not only_distance:
+            humanized = self._format_relative(humanized, timeframe, delta)
 
         return humanized
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -862,12 +862,19 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later), 'seconds ago')
         assertEqual(later.humanize(self.now), 'in seconds')
 
+        assertEqual(self.now.humanize(later, only_distance=True), 'seconds')
+        assertEqual(later.humanize(self.now, only_distance=True), 'seconds')
+
     def test_minute(self):
 
         later = self.now.replace(minutes=1)
 
         assertEqual(self.now.humanize(later), 'a minute ago')
         assertEqual(later.humanize(self.now), 'in a minute')
+
+        assertEqual(self.now.humanize(later, only_distance=True), 'a minute')
+        assertEqual(later.humanize(self.now, only_distance=True), 'a minute')
+
 
     def test_minutes(self):
 
@@ -876,12 +883,18 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later), '2 minutes ago')
         assertEqual(later.humanize(self.now), 'in 2 minutes')
 
+        assertEqual(self.now.humanize(later, only_distance=True), '2 minutes')
+        assertEqual(later.humanize(self.now, only_distance=True), '2 minutes')
+
     def test_hour(self):
 
         later = self.now.replace(hours=1)
 
         assertEqual(self.now.humanize(later), 'an hour ago')
         assertEqual(later.humanize(self.now), 'in an hour')
+
+        assertEqual(self.now.humanize(later, only_distance=True), 'an hour')
+        assertEqual(later.humanize(self.now, only_distance=True), 'an hour')
 
     def test_hours(self):
 
@@ -890,12 +903,18 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later), '2 hours ago')
         assertEqual(later.humanize(self.now), 'in 2 hours')
 
+        assertEqual(self.now.humanize(later, only_distance=True), '2 hours')
+        assertEqual(later.humanize(self.now, only_distance=True), '2 hours')
+
     def test_day(self):
 
         later = self.now.replace(days=1)
 
         assertEqual(self.now.humanize(later), 'a day ago')
         assertEqual(later.humanize(self.now), 'in a day')
+
+        assertEqual(self.now.humanize(later, only_distance=True), 'a day')
+        assertEqual(later.humanize(self.now, only_distance=True), 'a day')
 
     def test_days(self):
 
@@ -904,12 +923,18 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later), '2 days ago')
         assertEqual(later.humanize(self.now), 'in 2 days')
 
+        assertEqual(self.now.humanize(later, only_distance=True), '2 days')
+        assertEqual(later.humanize(self.now, only_distance=True), '2 days')
+
     def test_month(self):
 
         later = self.now.replace(months=1)
 
         assertEqual(self.now.humanize(later), 'a month ago')
         assertEqual(later.humanize(self.now), 'in a month')
+
+        assertEqual(self.now.humanize(later, only_distance=True), 'a month')
+        assertEqual(later.humanize(self.now, only_distance=True), 'a month')
 
     def test_months(self):
 
@@ -918,6 +943,9 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later), '2 months ago')
         assertEqual(later.humanize(self.now), 'in 2 months')
 
+        assertEqual(self.now.humanize(later, only_distance=True), '2 months')
+        assertEqual(later.humanize(self.now, only_distance=True), '2 months')
+
     def test_year(self):
 
         later = self.now.replace(years=1)
@@ -925,12 +953,18 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later), 'a year ago')
         assertEqual(later.humanize(self.now), 'in a year')
 
+        assertEqual(self.now.humanize(later, only_distance=True), 'a year')
+        assertEqual(later.humanize(self.now, only_distance=True), 'a year')
+
     def test_years(self):
 
         later = self.now.replace(years=2)
 
         assertEqual(self.now.humanize(later), '2 years ago')
         assertEqual(later.humanize(self.now), 'in 2 years')
+
+        assertEqual(self.now.humanize(later, only_distance=True), '2 years')
+        assertEqual(later.humanize(self.now, only_distance=True), '2 years')
 
         arw = arrow.Arrow(2014, 7, 2)
 


### PR DESCRIPTION
adds a param for humanized duration without "in" and "ago" prefix/suffix, maybe for things like "you been running for 8 minutes"

