### PR TITLE
Hungarian translation

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1426,4 +1426,65 @@ class BasqueLocale(Locale):
     day_abbreviations = ['', 'al', 'ar', 'az', 'og', 'ol', 'lr', 'ig']
 
 
+class HungarianLocale(Locale):
+
+    names = ['hu', 'hu_hu']
+
+    past = '{0} ezelőtt'
+    future = '{0} múlva'
+
+    timeframes = {
+        'now': 'éppen most',
+        'seconds': {
+            'past': 'másodpercekkel',
+            'future': 'pár másodperc'
+        },
+        'minute': {'past': 'egy perccel', 'future': 'egy perc'},
+        'minutes': {'past': '{0} perccel', 'future': '{0} perc'},
+        'hour': {'past': 'egy órával', 'future': 'egy óra'},
+        'hours': {'past': '{0} órával', 'future': '{0} óra'},
+        'day': {
+            'past': 'egy nappal',
+            'future': 'egy nap'
+        },
+        'days': {
+            'past': '{0} nappal',
+            'future': '{0} nap'
+        },
+        'month': {'past': 'egy hónappal', 'future': 'egy hónap'},
+        'months': {'past': '{0} hónappal', 'future': '{0} hónap'},
+        'year': {'past': 'egy évvel', 'future': 'egy év'},
+        'years': {'past': '{0} évvel', 'future': '{0} év'},
+    }
+
+    month_names = ['', 'Január', 'Február', 'Március', 'Április', 'Május',
+                   'Június', 'Július', 'Augusztus', 'Szeptember',
+                   'Október', 'November', 'December']
+    month_abbreviations = ['', 'Jan', 'Febr', 'Márc', 'Ápr', 'Máj', 'Jún',
+                           'Júl', 'Aug', 'Szept', 'Okt', 'Nov', 'Dec']
+
+    day_names = ['', 'Hétfő', 'Kedd', 'Szerda', 'Csütörtök', 'Péntek',
+                 'Szombat', 'Vasárnap']
+    day_abbreviations = ['', 'Hét', 'Kedd', 'Szer', 'Csüt', 'Pént',
+                         'Szom', 'Vas']
+
+    meridians = {
+        'am': 'de',
+        'pm': 'du',
+        'AM': 'DE',
+        'PM': 'DU',
+    }
+
+    def _format_timeframe(self, timeframe, delta):
+        form = self.timeframes[timeframe]
+
+        if isinstance(form, dict):
+            if delta > 0:
+                form = form['future']
+            else:
+                form = form['past']
+
+        return form.format(abs(delta))
+
+
 _locales = _map_locales()


### PR DESCRIPTION
```
just now        éppen most
in seconds      pár másodperc múlva
in a minute     egy perc múlva
in 4 minutes    4 perc múlva
in 29 minutes   29 perc múlva
in an hour      egy óra múlva
in 2 hours      2 óra múlva
in a day        egy nap múlva
in 2 days       2 nap múlva
in 6 days       6 nap múlva
in 13 days      13 nap múlva
in a month      egy hónap múlva
in 2 months     2 hónap múlva
in a year       egy év múlva
in 2 years      2 év múlva
just now        éppen most
seconds ago     másodpercekkel ezelőtt
a minute ago    egy perccel ezelőtt
5 minutes ago   5 perccel ezelőtt
30 minutes ago  30 perccel ezelőtt
an hour ago     egy órával ezelőtt
2 hours ago     2 órával ezelőtt
a day ago       egy nappal ezelőtt
2 days ago      2 nappal ezelőtt
7 days ago      7 nappal ezelőtt
14 days ago     14 nappal ezelőtt
a month ago     egy hónappal ezelőtt
2 months ago    2 hónappal ezelőtt
a year ago      egy évvel ezelőtt
2 years ago     2 évvel ezelőtt
```