### PR TITLE
import timedelta in __init__.py

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from datetime import timedelta
+
 from .arrow import Arrow
 from .factory import ArrowFactory
 from .api import get, now, utcnow


### PR DESCRIPTION
This makes things less annoying by allowing the user to import timedelta from arrow itself instead of arrow.util or datetime.