### PR TITLE
Search date in strings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,6 +138,13 @@ Parse from a string:
     >>> arrow.get('2013-05-05 12:30:45', 'YYYY-MM-DD HH:mm:ss')
     <Arrow [2013-05-05T12:30:45+00:00]>
 
+Search a date in a string:
+
+.. code-block:: python
+
+    >>> arrow.get('June was born in May 1980', 'MMMM YYYY')
+    <Arrow [1980-05-01T00:00:00+00:00]>
+
 Many ISO-8601 compliant strings are recognized and parsed without a format string:
 
     >>> arrow.get('2013-09-30T15:34:00.000-07:00')

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -621,3 +621,48 @@ class DateTimeParserMonthOrdinalDayTests(Chai):
 
         assertEqual(parser_.parse('Janvier 11e, 2013', 'MMMM Do, YYYY'),
                     datetime(2013, 1, 11))
+
+
+class DateTimeParserSearchDateTests(Chai):
+
+    def setUp(self):
+        super(DateTimeParserSearchDateTests, self).setUp()
+        self.parser = parser.DateTimeParser()
+
+    def test_parse_search(self):
+
+        assertEqual(
+            self.parser.parse('Today is 25 of September of 2003', 'DD of MMMM of YYYY'),
+            datetime(2003, 9, 25))
+
+    def test_parse_seach_with_numbers(self):
+
+        assertEqual(
+            self.parser.parse('2000 people met the 2012-01-01 12:05:10', 'YYYY-MM-DD HH:mm:ss'),
+            datetime(2012, 1, 1, 12, 5, 10))
+
+        assertEqual(
+            self.parser.parse('Call 01-02-03 on 79-01-01 12:05:10', 'YY-MM-DD HH:mm:ss'),
+            datetime(1979, 1, 1, 12, 5, 10))
+
+    def test_parse_seach_with_names(self):
+
+        assertEqual(
+            self.parser.parse('June was born in May 1980', 'MMMM YYYY'),
+            datetime(1980, 5, 1))
+
+    def test_parse_seach_locale_with_names(self):
+        p = parser.DateTimeParser('sv_se')
+
+        assertEqual(
+            p.parse('Jan föddes den 31 Dec 1980', 'DD MMM YYYY'),
+            datetime(1980, 12, 31))
+
+        assertEqual(
+            p.parse('Jag föddes den 25 Augusti 1975', 'DD MMMM YYYY'),
+            datetime(1975, 8, 25))
+
+    def test_parse_seach_fails(self):
+
+        with assertRaises(parser.ParserError):
+            self.parser.parse('Jag föddes den 25 Augusti 1975', 'DD MMMM YYYY')


### PR DESCRIPTION
Unknown tokens in the string are ignored.

In the previous implementation, each token was matched individually.
With the format 'YYYY-MM-DD', parsing the string '2000 ... 2015-12-31'
would fail because 'YYYY' taken alone matches the first 4 numbers.

Same with the format 'MMMM YYYY' and the string 'June was born in May
1980'. 'MMMM' would match 'June' instead of 'May' even if there are no
digits next to it.

This change builds a complete pattern string by replacing each token by
its pattern. 'YYYY-MM-DD' becomes '(?P<YYYY>\d{4})-(?P<MM>\d{2})-(?P<DD>\d{2})'.
The search is done with that string.
That matches '2015-12-31' in the previous example.