### PR TITLE
Raise TypeError when adding/subtracting non-dates

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -669,7 +669,7 @@ class Arrow(object):
         if isinstance(other, (timedelta, relativedelta)):
             return self.fromdatetime(self._datetime + other, self._datetime.tzinfo)
 
-        raise NotImplementedError()
+        raise TypeError()
 
     def __radd__(self, other):
         return self.__add__(other)
@@ -685,7 +685,7 @@ class Arrow(object):
         elif isinstance(other, Arrow):
             return self._datetime - other._datetime
 
-        raise NotImplementedError()
+        raise TypeError()
 
     def __rsub__(self, other):
         return self.__sub__(other)

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -261,7 +261,7 @@ class ArrowMathTests(Chai):
 
     def test_add_other(self):
 
-        with assertRaises(NotImplementedError):
+        with assertRaises(TypeError):
             self.arrow.__add__(1)
 
     def test_radd(self):
@@ -290,7 +290,7 @@ class ArrowMathTests(Chai):
 
     def test_sub_other(self):
 
-        with assertRaises(NotImplementedError):
+        with assertRaises(TypeError):
             self.arrow.__sub__(object())
 
     def test_rsub(self):
@@ -1121,4 +1121,3 @@ class ArrowUtilTests(Chai):
 
         with assertRaises(Exception):
             arrow.Arrow._get_iteration_params(None, None)
-


### PR DESCRIPTION
Here's what used to happen:
```py
arrow.utcnow() + None #=> raises NotImplementedError()
```
Now: 
```py
arrow.utcnow() + None #=> raises TypeError()
```

Fixes #241.

I'm not sure this is actually what should be happening but I already wrote it when I read that TypeError should not be raised.