### PR TITLE
Fix pytz conversion error

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -464,7 +464,7 @@ class Arrow(object):
         dt = self._datetime.astimezone(tz)
 
         return self.__class__(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
-            dt.microsecond, tz)
+            dt.microsecond, dt.tzinfo)
 
     def span(self, frame, count=1):
         ''' Returns two new :class:`Arrow <arrow.arrow.Arrow>` objects, representing the timespan


### PR DESCRIPTION
I have an issue to report and not sure if it is related #154 .

I have the issue that `arrow.to()` return wrong offset as well.
According to [pytz's README](http://bazaar.launchpad.net/~stub/pytz/devel/view/head:/src/README.txt), caller should call `zone_instance.localize()` instead of just passing zone_instance to standard python datetime.
 
From arrow.to()'s internal implementation, we should assign new arrow instance with astimezone() returned timezone which is correct from zone.localize().

Tested with #154 's case: ( arrow==0.5.4 , pytz==2015.4 )

```
In [1]: import arrow

In [2]: import pytz

In [3]: str(arrow.utcnow().to(pytz.timezone("America/Los_Angeles")).datetime)
Out[3]: '2015-08-03 03:00:50.856870-07:00'

In [4]: str(arrow.utcnow().to(pytz.timezone("America/Los_Angeles")))
Out[4]: '2015-08-03T03:01:47.165010-07:00'

In [5]: str(arrow.utcnow().to("America/Los_Angeles").datetime)
Out[5]: '2015-08-03 03:01:57.318926-07:00'

In [6]: str(arrow.utcnow().to("America/Los_Angeles"))
Out[6]: '2015-08-03T03:02:02.303030-07:00'
```