### PR TITLE
Fix overzealous time truncation in span_range()

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -270,7 +270,7 @@ class Arrow(object):
 
         '''
         tzinfo = cls._get_tzinfo(start.tzinfo if tz is None else tz)
-        start = cls.fromdate(start, tzinfo).span(frame)[0]
+        start = cls.fromdatetime(start, tzinfo).span(frame)[0]
         _range = cls.range(frame, start, end, tz, limit)
         return [r.span(frame) for r in _range]
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -569,6 +569,13 @@ class ArrowRangeTests(Chai):
             arrow.Arrow(2013, 1, 2, 6, 4, 5),
         ])
 
+        result = arrow.Arrow.range('hour', datetime(2013, 1, 2, 3, 4, 5),
+            datetime(2013, 1, 2, 3, 4, 5))
+
+        assertEqual(result, [
+            arrow.Arrow(2013, 1, 2, 3, 4, 5),
+        ])
+
     def test_minute(self):
 
         result = arrow.Arrow.range('minute', datetime(2013, 1, 2, 3, 4, 5),
@@ -710,6 +717,13 @@ class ArrowSpanRangeTests(Chai):
             (arrow.Arrow(2013, 1, 1, 0), arrow.Arrow(2013, 1, 1, 0, 59, 59, 999999)),
             (arrow.Arrow(2013, 1, 1, 1), arrow.Arrow(2013, 1, 1, 1, 59, 59, 999999)),
             (arrow.Arrow(2013, 1, 1, 2), arrow.Arrow(2013, 1, 1, 2, 59, 59, 999999)),
+            (arrow.Arrow(2013, 1, 1, 3), arrow.Arrow(2013, 1, 1, 3, 59, 59, 999999)),
+        ])
+
+        result = arrow.Arrow.span_range('hour', datetime(2013, 1, 1, 3, 30),
+            datetime(2013, 1, 1, 3, 30))
+
+        assertEqual(result, [
             (arrow.Arrow(2013, 1, 1, 3), arrow.Arrow(2013, 1, 1, 3, 59, 59, 999999)),
         ])
 


### PR DESCRIPTION
In the recently released arrow 0.6.0, the ``span_range`` method now returns superfluous ranges.

The lower bound gets artificially rounded to the day granularity:
```python
$ python
Python 2.7.10 (default, Jun 10 2015, 19:42:47) 
[GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)] on darwin
>>> import arrow
>>> arrow.__version__
'0.6.0'
>>> now = arrow.utcnow()
>>> now
<Arrow [2015-07-20T12:38:22.561417+00:00]>
>>> arrow.Arrow.span_range('hour', now, now)
[(<Arrow [2015-07-20T00:00:00+00:00]>,
  <Arrow [2015-07-20T00:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T01:00:00+00:00]>,
  <Arrow [2015-07-20T01:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T02:00:00+00:00]>,
  <Arrow [2015-07-20T02:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T03:00:00+00:00]>,
  <Arrow [2015-07-20T03:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T04:00:00+00:00]>,
  <Arrow [2015-07-20T04:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T05:00:00+00:00]>,
  <Arrow [2015-07-20T05:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T06:00:00+00:00]>,
  <Arrow [2015-07-20T06:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T07:00:00+00:00]>,
  <Arrow [2015-07-20T07:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T08:00:00+00:00]>,
  <Arrow [2015-07-20T08:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T09:00:00+00:00]>,
  <Arrow [2015-07-20T09:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T10:00:00+00:00]>,
  <Arrow [2015-07-20T10:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T11:00:00+00:00]>,
  <Arrow [2015-07-20T11:59:59.999999+00:00]>),
 (<Arrow [2015-07-20T12:00:00+00:00]>,
  <Arrow [2015-07-20T12:59:59.999999+00:00]>)]
>>> 
```

Here I expect arrow to keep the date range within the hour granularity and returns:
```python
>>> arrow.Arrow.span_range('hour', now, now)
[(<Arrow [2015-07-20T12:00:00+00:00]>,
  <Arrow [2015-07-20T12:59:59.999999+00:00]>)]
```

Looks like this regression was introduced by the b2b90d4339abcc1b1cbacf14a5306a39ad5a6e24 commit.