### PR TITLE
Throw TypeError when passing booleans to arrow.get

### DIFF
--- a/arrow/util.py
+++ b/arrow/util.py
@@ -23,6 +23,8 @@ else: # pragma: no cover
     total_seconds = _total_seconds_27
 
 def is_timestamp(value):
+    if type(value) == bool:
+        return False
     try:
         float(value)
         return True

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -95,6 +95,14 @@ class GetTests(Chai):
         with assertRaises(TypeError):
             self.factory.get(object())
 
+    def test_one_arg_bool(self):
+
+        with assertRaises(TypeError):
+            self.factory.get(False)
+
+        with assertRaises(TypeError):
+            self.factory.get(True)
+
     def test_two_args_datetime_tzinfo(self):
 
         result = self.factory.get(datetime(2013, 1, 1), tz.gettz('US/Pacific'))
@@ -190,4 +198,3 @@ class NowTests(Chai):
     def test_tz_str(self):
 
         assertDtEqual(self.factory.now('EST'), datetime.now(tz.gettz('EST')))
-


### PR DESCRIPTION
Before:

```
>>> arrow.get(False)
<Arrow [1970-01-01T00:00:00+00:00]>

>>> arrow.get(True)
<Arrow [1970-01-01T00:00:01+00:00]>
```

After:

```
>>> arrow.get(False)
TypeError: Can't parse single argument type of '<type 'bool'>'

>>> arrow.get(True)
TypeError: Can't parse single argument type of '<type 'bool'>'
```

Closes #238.
