### PR TITLE
Fix #263: provide missing format calls for exception messages

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -839,7 +839,8 @@ class Arrow(object):
             try:
                 return parser.TzinfoParser.parse(tz_expr)
             except parser.ParserError:
-                raise ValueError('\'{0}\' not recognized as a timezone')
+                raise ValueError('\'{0}\' not recognized as a timezone'.format(
+                    tz_expr))
 
     @classmethod
     def _get_datetime(cls, expr):
@@ -854,7 +855,8 @@ class Arrow(object):
             expr = float(expr)
             return cls.utcfromtimestamp(expr).datetime
         except:
-            raise ValueError('\'{0}\' not recognized as a timestamp or datetime')
+            raise ValueError(
+                '\'{0}\' not recognized as a timestamp or datetime'.format(expr))
 
     @classmethod
     def _get_frames(cls, name):

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1094,15 +1094,17 @@ class ArrowUtilTests(Chai):
         assertEqual(get_datetime(dt), dt)
         assertEqual(get_datetime(timestamp), arrow.Arrow.utcfromtimestamp(timestamp).datetime)
 
-        with assertRaises(ValueError):
+        with assertRaises(ValueError) as raise_ctx:
             get_datetime('abc')
+        assertFalse('{0}' in raise_ctx.exception.message)
 
     def test_get_tzinfo(self):
 
         get_tzinfo = arrow.Arrow._get_tzinfo
 
-        with assertRaises(ValueError):
+        with assertRaises(ValueError) as raise_ctx:
             get_tzinfo('abc')
+        assertFalse('{0}' in raise_ctx.exception.message)
 
     def test_get_timestamp_from_input(self):
 


### PR DESCRIPTION
Just a minor fix.