### PR TITLE
Extend parseable formats

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -52,6 +52,9 @@ class DateTimeParser(object):
         'S': re.compile('\d'),
     }
 
+    MARKERS = ['YYYY', 'MM', 'DD']
+    SEPARATORS = ['-', '/', '.']
+
     def __init__(self, locale='en_us'):
 
         self.locale = locales.get_locale(locale)
@@ -93,11 +96,12 @@ class DateTimeParser(object):
                 formats = ['YYYY-MM-DDTHH:mm']
         else:
             has_tz = False
-            formats = [
-                'YYYY-MM-DD',
-                'YYYY-MM',
-                'YYYY',
-            ]
+            # generate required formats: YYYY-MM-DD, YYYY-MM-DD, YYYY
+            # using various separators: -, /, .
+            l = len(self.MARKERS)
+            formats = [separator.join(self.MARKERS[:l-i])
+                        for i in range(l)
+                        for separator in self.SEPARATORS]
 
         if has_time and has_tz:
             formats = [f + 'Z' for f in formats]

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -8,7 +8,7 @@ import calendar
 import time
 
 from arrow import parser
-from arrow.parser import ParserError
+from arrow.parser import DateTimeParser, ParserError
 
 
 class DateTimeParserTests(Chai):
@@ -258,17 +258,19 @@ class DateTimeParserISOTests(Chai):
 
     def test_YYYY_MM(self):
 
-        assertEqual(
-            self.parser.parse_iso('2013-02'),
-            datetime(2013, 2, 1)
-        )
+        for separator in DateTimeParser.SEPARATORS:
+            assertEqual(
+                self.parser.parse_iso(separator.join(('2013', '02'))),
+                datetime(2013, 2, 1)
+            )
 
     def test_YYYY_MM_DD(self):
 
-        assertEqual(
-            self.parser.parse_iso('2013-02-03'),
-            datetime(2013, 2, 3)
-        )
+        for separator in DateTimeParser.SEPARATORS:
+            assertEqual(
+                self.parser.parse_iso(separator.join(('2013', '02', '03'))),
+                datetime(2013, 2, 3)
+            )
 
     def test_YYYY_MM_DDTHH_mmZ(self):
 


### PR DESCRIPTION
Hi!

So, I've added more separators (`- / .`) for parsing to fix #174.
Additionally, I've added tests for them, as per #242.

Cheers!