### PR TITLE
Add SwissGerman localization

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -838,6 +838,49 @@ class AustriaLocale(Locale):
             '', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'
         ]
 
+
+class SwissLocale(Locale):
+
+    names = ['de', 'de_ch']
+
+    past = 'vor {0}'
+    future = 'in {0}'
+
+    timeframes = {
+            'now': 'gerade eben',
+            'seconds':  'Sekunden',
+            'minute': 'einer Minute',
+            'minutes': '{0} Minuten',
+            'hour': 'einer Stunde',
+            'hours': '{0} Stunden',
+            'day': 'einem Tag',
+            'days': '{0} Tage',
+            'month': 'einem Monat',
+            'months': '{0} Monaten',
+            'year': 'einem Jahr',
+            'years': '{0} Jahren',
+        }
+
+    month_names = [
+            '', 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli',
+            'August', 'September', 'Oktober', 'November', 'Dezember'
+        ]
+
+    month_abbreviations = [
+            '', 'Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep',
+            'Okt', 'Nov', 'Dez'
+        ]
+
+    day_names = [
+            '', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag',
+            'Samstag', 'Sonntag'
+        ]
+
+    day_abbreviations = [
+            '', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'
+        ]
+
+
 class NorwegianLocale(Locale):
 
     names = ['nb', 'nb_no']

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -309,3 +309,15 @@ class MarathiLocaleTests(Chai):
     # Not currently implemented
     def test_ordinal_number(self):
         assertEqual(self.locale.ordinal_number(1), '1')
+
+
+class SwissLocalesTests(Chai):
+
+    def test_ordinal_number(self):
+        self.locale = locales.SwissLocale()
+
+        dt = arrow.Arrow(2015, 4, 11, 17, 30, 00)
+
+        assertEqual(self.locale._format_timeframe('minute', 1), 'einer Minute')
+        assertEqual(self.locale._format_timeframe('hour', 1), 'einer Stunde')
+        assertEqual(self.locale.day_abbreviation(dt.isoweekday()), 'Sa')


### PR DESCRIPTION
This enables 'de_ch'. It's another class even though it's the exact same as 'de_de' and 'de_at'. But if there's every anything else that needs to be added in the future there is a good chance that they will diverge. So personally I think breaking DRY here is reasonable.

I also added what is basically a smoke test.
