### PR TITLE
parser: add new ZZZ token to recognize/parse TZ names from the tz database

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -15,7 +15,7 @@ class ParserError(RuntimeError):
 
 class DateTimeParser(object):
 
-    _FORMAT_RE = re.compile('(YYY?Y?|MM?M?M?|Do|DD?D?D?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?|a|A|X)')
+    _FORMAT_RE = re.compile('(YYY?Y?|MM?M?M?|Do|DD?D?D?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X)')
 
     _ONE_THROUGH_SIX_DIGIT_RE = re.compile('\d{1,6}')
     _ONE_THROUGH_FIVE_DIGIT_RE = re.compile('\d{1,5}')
@@ -25,6 +25,8 @@ class DateTimeParser(object):
     _FOUR_DIGIT_RE = re.compile('\d{4}')
     _TWO_DIGIT_RE = re.compile('\d{2}')
     _TZ_RE = re.compile('[+\-]?\d{2}:?\d{2}')
+    _TZ_NAME_RE = re.compile('\w[\w+\-/]+')
+
 
     _BASE_INPUT_RE_MAP = {
         'YYYY': _FOUR_DIGIT_RE,
@@ -42,6 +44,7 @@ class DateTimeParser(object):
         'ss': _TWO_DIGIT_RE,
         's': _ONE_OR_TWO_DIGIT_RE,
         'X': re.compile('\d+'),
+        'ZZZ': _TZ_NAME_RE,
         'ZZ': _TZ_RE,
         'Z': _TZ_RE,
         'SSSSSS': _ONE_THROUGH_SIX_DIGIT_RE,
@@ -194,7 +197,7 @@ class DateTimeParser(object):
         elif token == 'X':
             parts['timestamp'] = int(value)
 
-        elif token in ['ZZ', 'Z']:
+        elif token in ['ZZZ', 'ZZ', 'Z']:
             parts['tzinfo'] = TzinfoParser.parse(value)
 
         elif token in ['a', 'A']:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -434,7 +434,9 @@ Use the following tokens in parsing and formatting.  Note that they're not the s
 +--------------------------------+--------------+-------------------------------------------+
 |                                |S             |0, 1, 2 ... 8, 9                           |
 +--------------------------------+--------------+-------------------------------------------+
-|**Timezone**                    |ZZ            |-07:00, -06:00 ... +06:00, +07:00          |
+|**Timezone**                    |ZZZ           |Asia/Baku, Europe/Warsaw, GMT ... [#t3]_   |
++--------------------------------+--------------+-------------------------------------------+
+|                                |ZZ            |-07:00, -06:00 ... +06:00, +07:00          |
 +--------------------------------+--------------+-------------------------------------------+
 |                                |Z             |-0700, -0600 ... +0600, +0700              |
 +--------------------------------+--------------+-------------------------------------------+
@@ -445,6 +447,7 @@ Use the following tokens in parsing and formatting.  Note that they're not the s
 
 .. [#t1] localization support for parsing and formatting
 .. [#t2] localization support only for formatting
+.. [#t3] timezone names from `tz database <https://www.iana.org/time-zones>`_  provided via dateutil package
 
 ---------
 API Guide

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -114,10 +114,35 @@ class DateTimeParserParseTests(Chai):
         assertEqual(self.parser.parse('12 pm', 'H A'), expected)
         assertEqual(self.parser.parse('12 pm', 'h A'), expected)
 
-    def test_parse_tz(self):
+    def test_parse_tz_zz(self):
 
         expected = datetime(2013, 1, 1, tzinfo=tz.tzoffset(None, -7 * 3600))
         assertEqual(self.parser.parse('2013-01-01 -07:00', 'YYYY-MM-DD ZZ'), expected)
+
+    def test_parse_tz_name_zzz(self):
+        for tz_name in (
+            # best solution would be to test on every available tz name from
+            # the tz database but it is actualy tricky to retrieve them from
+            # dateutil so here is short list that should match all
+            # naming patterns/conventions in used tz databaze
+            'Africa/Tripoli',
+            'America/Port_of_Spain',
+            'Australia/LHI',
+            'Etc/GMT-11',
+            'Etc/GMT0',
+            'Etc/UCT',
+            'Etc/GMT+9',
+            'GMT+0',
+            'CST6CDT',
+            'GMT-0',
+            'W-SU',
+        ):
+            expected = datetime(2013, 1, 1, tzinfo=tz.gettz(tz_name))
+            assertEqual(self.parser.parse('2013-01-01 %s' % tz_name, 'YYYY-MM-DD ZZZ'), expected)
+
+        # note that offsets are not timezones
+        with assertRaises(ParserError):
+            self.parser.parse('2013-01-01 +1000', 'YYYY-MM-DD ZZZ')
 
     def test_parse_subsecond(self):
 


### PR DESCRIPTION
Solution proposed as a fix to issue #275  

* try to test various available tz naming conventions
* rename existing `test_parse_tz` to `test_parse_tz_zz` in order
  to separate ZZ tests from ZZZ
* update token table in docs
* add new regex for ZZZ token and leverage existing code that recognizes
  timezones via dateutil

This does not include improvements (refactoring) to existing code proposed also in the issue thread.