### PR TITLE
Fix test errors caused by `Exception.message` which is removed since Python 3.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 *.pyc
 *.egg-info
 
+# temporary files created by VIM
+*.swp
+*.swo
+
+# temporary files created by git/patch
+*.orig
+
 .coverage
 nosetests.xml
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1110,7 +1110,7 @@ class ArrowUtilTests(Chai):
 
         with assertRaises(ValueError) as raise_ctx:
             get_datetime('abc')
-        assertFalse('{0}' in raise_ctx.exception.message)
+        assertFalse('{0}' in str(raise_ctx.exception))
 
     def test_get_tzinfo(self):
 
@@ -1118,7 +1118,7 @@ class ArrowUtilTests(Chai):
 
         with assertRaises(ValueError) as raise_ctx:
             get_tzinfo('abc')
-        assertFalse('{0}' in raise_ctx.exception.message)
+        assertFalse('{0}' in str(raise_ctx.exception))
 
     def test_get_timestamp_from_input(self):
 


### PR DESCRIPTION
Just a patch of `arrow_tests.py` to fix the Python 3 errors and added some general `.gitignore` file patterns for `vim` and `patch`.

The error was introduced in pull request #264.