### PR TITLE
Added support for escaping within parsing formats

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -148,13 +148,12 @@ class DateTimeParser(object):
             offset += len(input_pattern) - (m.end() - m.start())
 
         final_fmt_pattern = ""
-
         a = fmt_pattern.split("#")
         b = escaped_data
 
-        for i in range(max(len(a), len(b))):
-            if i < len(a):
-                final_fmt_pattern += a[i]
+        # Due to the way Python splits, 'a' will always be longer
+        for i in range(len(a)):
+            final_fmt_pattern += a[i]
             if i < len(b):
                 final_fmt_pattern += b[i][1:-1]
 

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -148,8 +148,15 @@ class DateTimeParser(object):
             offset += len(input_pattern) - (m.end() - m.start())
 
         final_fmt_pattern = ""
-        for pattern_part, escaped in zip(fmt_pattern.split("#"), escaped_data + [""]):
-            final_fmt_pattern += pattern_part + escaped[1:-1]
+
+        a = fmt_pattern.split("#")
+        b = escaped_data
+
+        for i in range(max(len(a), len(b))):
+            if i < len(a):
+                final_fmt_pattern += a[i]
+            if i < len(b):
+                final_fmt_pattern += b[i][1:-1]
 
         match = re.search(final_fmt_pattern, string, flags=re.IGNORECASE)
         if match is None:

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -719,7 +719,7 @@ class DateTimeParserSearchDateTests(Chai):
             self.parser.parse("MMMM 12 10, 2015 at 5:09pm", format),
             datetime(2015, 12, 10, 17, 9))
 
-        format = "[It happened on] MMMM Do [in the year] YYYY"
+        format = "[It happened on] MMMM Do [in the] [year] YYYY [a long time ago]"
         assertEqual(
-            self.parser.parse("It happened on November 25th in the year 1990", format),
+            self.parser.parse("It happened on November 25th in the year 1990 a long time ago", format),
             datetime(1990, 11, 25))

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -675,7 +675,7 @@ class DateTimeParserSearchDateTests(Chai):
             self.parser.parse('Today is 25 of September of 2003', 'DD of MMMM of YYYY'),
             datetime(2003, 9, 25))
 
-    def test_parse_seach_with_numbers(self):
+    def test_parse_search_with_numbers(self):
 
         assertEqual(
             self.parser.parse('2000 people met the 2012-01-01 12:05:10', 'YYYY-MM-DD HH:mm:ss'),
@@ -685,13 +685,13 @@ class DateTimeParserSearchDateTests(Chai):
             self.parser.parse('Call 01-02-03 on 79-01-01 12:05:10', 'YY-MM-DD HH:mm:ss'),
             datetime(1979, 1, 1, 12, 5, 10))
 
-    def test_parse_seach_with_names(self):
+    def test_parse_search_with_names(self):
 
         assertEqual(
             self.parser.parse('June was born in May 1980', 'MMMM YYYY'),
             datetime(1980, 5, 1))
 
-    def test_parse_seach_locale_with_names(self):
+    def test_parse_search_locale_with_names(self):
         p = parser.DateTimeParser('sv_se')
 
         assertEqual(
@@ -702,7 +702,24 @@ class DateTimeParserSearchDateTests(Chai):
             p.parse('Jag föddes den 25 Augusti 1975', 'DD MMMM YYYY'),
             datetime(1975, 8, 25))
 
-    def test_parse_seach_fails(self):
+    def test_parse_search_fails(self):
 
         with assertRaises(parser.ParserError):
             self.parser.parse('Jag föddes den 25 Augusti 1975', 'DD MMMM YYYY')
+
+    def test_escape(self):
+
+        format = "MMMM D, YYYY [at] h:mma"
+        assertEqual(
+            self.parser.parse("Thursday, December 10, 2015 at 5:09pm", format),
+            datetime(2015, 12, 10, 17, 9))
+
+        format = "[MMMM] M D, YYYY [at] h:mma"
+        assertEqual(
+            self.parser.parse("MMMM 12 10, 2015 at 5:09pm", format),
+            datetime(2015, 12, 10, 17, 9))
+
+        format = "[It happened on] MMMM Do [in the year] YYYY"
+        assertEqual(
+            self.parser.parse("It happened on November 25th in the year 1990", format),
+            datetime(1990, 11, 25))

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -719,6 +719,11 @@ class DateTimeParserSearchDateTests(Chai):
             self.parser.parse("MMMM 12 10, 2015 at 5:09pm", format),
             datetime(2015, 12, 10, 17, 9))
 
+        format = "[It happened on] MMMM Do [in the year] YYYY [a long time ago]"
+        assertEqual(
+            self.parser.parse("It happened on November 25th in the year 1990 a long time ago", format),
+            datetime(1990, 11, 25))
+
         format = "[It happened on] MMMM Do [in the] [year] YYYY [a long time ago]"
         assertEqual(
             self.parser.parse("It happened on November 25th in the year 1990 a long time ago", format),

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -724,7 +724,12 @@ class DateTimeParserSearchDateTests(Chai):
             self.parser.parse("It happened on November 25th in the year 1990 a long time ago", format),
             datetime(1990, 11, 25))
 
-        format = "[It happened on] MMMM Do [in the] [year] YYYY [a long time ago]"
+        format = "[It happened on] MMMM Do [in the][ year] YYYY [a long time ago]"
         assertEqual(
             self.parser.parse("It happened on November 25th in the year 1990 a long time ago", format),
             datetime(1990, 11, 25))
+
+        format = "[I'm][ entirely][ escaped,][ weee!]"
+        assertEqual(
+            self.parser.parse("I'm entirely escaped, weee!", format),
+            datetime(1, 1, 1))


### PR DESCRIPTION
It is currently impossible to parse dates which contain data matching an internal pattern used by arrow.

For example, `Thursday, December 10, 2015 at 5:09pm -0700`. A format string for arrow to parse this would be, `MMMM D, YYYY at h:mma Z`.

Unfortunately, this doesn't work because the `a` in `at` gets interpreted as the marker for am/pm parsing in accordance with the documentation [here](http://crsmithdev.com/arrow/#tokens).

This pull request offers a workaround by escaping anything that is square bracketed within a format and interpreting it as only text.

This fixes the above pattern: `MMMM D, YYYY [at] h:mma Z`

Arrow can now successfully parse the expression:
```python
>>> import arrow
>>> DATE_FORMAT = "MMMM D, YYYY [at] h:mma Z"
>>> my_date = "Thursday, December 10, 2015 at 5:09pm -0700" 
>>> arrow.get(my_date, DATE_FORMAT)
'<Arrow [2015-12-10T17:09:00-07:00]>'
```

The only caveat as that `#` must be escaped in all parsing formats with `[#]`, as it's used as the replacement character when the expression is being built.