### PR TITLE
adding arrow.quarter property and relative `replace` options

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -408,13 +408,20 @@ class Arrow(object):
 
             if key in self._ATTRS:
                 absolute_kwargs[key] = value
-            elif key in self._ATTRS_PLURAL or key == 'weeks':
+            elif key in self._ATTRS_PLURAL or key in ['weeks', 'quarters']:
                 relative_kwargs[key] = value
-            elif key == 'week':
-                raise AttributeError('setting absolute week is not supported')
+            elif key in ['week', 'quarter']:
+                raise AttributeError('setting absolute {} is not supported'.format(key))
             elif key !='tzinfo':
                 raise AttributeError()
 
+        # core datetime does not support quarters, translate to months.
+        if 'quarters' in relative_kwargs.keys():
+            if relative_kwargs.get('months') is None:
+                relative_kwargs['months'] = 0
+            relative_kwargs['months'] += (value * self._MONTHS_PER_QUARTER)
+            relative_kwargs.pop('quarters')
+            
         current = self._datetime.replace(**absolute_kwargs)
         current += relativedelta(**relative_kwargs)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -45,6 +45,7 @@ class Arrow(object):
 
     _ATTRS = ['year', 'month', 'day', 'hour', 'minute', 'second', 'microsecond']
     _ATTRS_PLURAL = ['{0}s'.format(a) for a in _ATTRS]
+    _MONTHS_PER_QUARTER = 3
 
     def __init__(self, year, month, day, hour=0, minute=0, second=0, microsecond=0,
                  tzinfo=None):
@@ -305,6 +306,9 @@ class Arrow(object):
 
         if name == 'week':
             return self.isocalendar()[1]
+
+        if name == 'quarter':
+            return int(self.month/self._MONTHS_PER_QUARTER) + 1
 
         if not name.startswith('_'):
             value = getattr(self._datetime, name, None)

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -168,7 +168,7 @@ class ArrowAttributeTests(Chai):
         assertEqual(q1.quarter, 1)
         assertEqual(q2.quarter, 2)
         assertEqual(q3.quarter, 3)
-        assertEqual(q4.quarter, 4)        
+        assertEqual(q4.quarter, 4)
 
     def test_getattr_dt_value(self):
 
@@ -465,6 +465,8 @@ class ArrowReplaceTests(Chai):
         arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
 
         assertEqual(arw.replace(years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=1), arrow.Arrow(2013, 8, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=1, months=1), arrow.Arrow(2013, 9, 5, 12, 30, 45))
         assertEqual(arw.replace(months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
         assertEqual(arw.replace(weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
         assertEqual(arw.replace(days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -160,6 +160,16 @@ class ArrowAttributeTests(Chai):
 
         assertEqual(self.arrow.week, 1)
 
+    def test_getattr_quarter(self):
+        q1 = arrow.Arrow(2013, 1, 1)
+        q2 = arrow.Arrow(2013, 4, 1)
+        q3 = arrow.Arrow(2013, 8, 1)
+        q4 = arrow.Arrow(2013, 10, 1)
+        assertEqual(q1.quarter, 1)
+        assertEqual(q2.quarter, 2)
+        assertEqual(q3.quarter, 3)
+        assertEqual(q4.quarter, 4)        
+
     def test_getattr_dt_value(self):
 
         assertEqual(self.arrow.year, 2013)


### PR DESCRIPTION
While I saw quarters used in `range` and `span_range`, I didn't see a way to have an instance property, e.g.

```python
a = arrow.utcnow()
print(a.quarter) # 1,2,3, or 4
```