### PR TITLE
Fix typo in docs for using arrow.ArrowFactory

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -364,7 +364,7 @@ Then get and use a factory for it:
 
 .. code-block:: python
 
-    >>> factory = arrow.Factory(CustomArrow)
+    >>> factory = arrow.ArrowFactory(CustomArrow)
     >>> custom = factory.utcnow()
     >>> custom
     >>> <CustomArrow [2013-05-27T23:35:35.533160+00:00]>


### PR DESCRIPTION
Perhaps the name changed along the way or it was a typo thinking of the fully qualified class name `arrow.factory.ArrowFactory`.