### PR TITLE
fixed #301: __rsub__ returns timedelta of opposite sign

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -688,7 +688,11 @@ class Arrow(object):
         raise TypeError()
 
     def __rsub__(self, other):
-        return self.__sub__(other)
+
+        if isinstance(other, datetime):
+            return other - self._datetime
+
+        raise TypeError()
 
 
     # comparisons

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -293,11 +293,16 @@ class ArrowMathTests(Chai):
         with assertRaises(TypeError):
             self.arrow.__sub__(object())
 
-    def test_rsub(self):
+    def test_rsub_datetime(self):
 
-        result = self.arrow.__rsub__(timedelta(days=1))
+        result = self.arrow.__rsub__(datetime(2012, 12, 21, tzinfo=tz.tzutc()))
 
-        assertEqual(result._datetime, datetime(2012, 12, 31, tzinfo=tz.tzutc()))
+        assertEqual(result, timedelta(days=-11))
+
+    def test_rsub_other(self):
+
+        with assertRaises(TypeError):
+            self.arrow.__rsub__(timedelta(days=1))
 
 
 class ArrowDatetimeInterfaceTests(Chai):


### PR DESCRIPTION
Fixes https://github.com/crsmithdev/arrow/issues/301

The correct implementation of magic methods should return NotImplemented rather than raising a TypeError. I kept it this way to be consistent with other methods.

Same applies to tests: they should use arithmetic operators, rather than calling the magic methods directly. Again, I'm keeping consistency with existing tests.

I can submit another PR to address these issues.