### PR TITLE
Update Japanese local

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -379,7 +379,7 @@ class JapaneseLocale(Locale):
 
     timeframes = {
         'now': '現在',
-        'seconds': '秒',
+        'seconds': '数秒',
         'minute': '1分',
         'minutes': '{0}分',
         'hour': '1時間',


### PR DESCRIPTION
- "秒" into "数秒"
- It will be "秒前" and "秒後" after it has be concatenated.
- It doesn't make sense (smattering).