### PR TITLE
included error message

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -413,7 +413,7 @@ class Arrow(object):
             elif key in ['week', 'quarter']:
                 raise AttributeError('setting absolute {0} is not supported'.format(key))
             elif key !='tzinfo':
-                raise AttributeError()
+                raise AttributeError('unknown attribute: "{0}"'.format(key))
 
         # core datetime does not support quarters, translate to months.
         if 'quarters' in relative_kwargs.keys():


### PR DESCRIPTION
Added error description at AttributeError on invalid `Arrow.replace` key.

When passing an invalid key to `Arrow.replace`, the invalid key is included in the message:

    >>> arrow.now().replace(foo: 42)
    AttributeError: unknown attribute: "foo"