### PR TITLE
Update Korean Locale

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -559,8 +559,8 @@ class KoreanLocale(Locale):
 
     timeframes = {
         'now': '지금',
-        'seconds': '몇초',
-        'minute': '일 분',
+        'seconds': '몇 초',
+        'minute': '1분',
         'minutes': '{0}분',
         'hour': '1시간',
         'hours': '{0}시간',


### PR DESCRIPTION
I had two improvements about Korean Locale.
 1. "몇초" to "몇 초": See [Rules of Korean spelling (Section 43)](http://www.korean.go.kr/front/page/pageView.do?page_id=P000074) (Korean). It says noun that expressing unit should leave space.
 2. "일 분" to "1분": Keep consistency with below `'minutes'`.