### PR TITLE
Ordinal pattern fix for Italian & Spanish

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -263,10 +263,10 @@ class ItalianLocale(Locale):
     day_names = ['', 'lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato', 'domenica']
     day_abbreviations = ['', 'lun', 'mar', 'mer', 'gio', 'ven', 'sab', 'dom']
 
-    ordinal_day_re = r'((?P<value>[1-3]?[0-9](?=°))°)'
+    ordinal_day_re = r'((?P<value>[1-3]?[0-9](?=[ºª]))[ºª])'
 
     def _ordinal_number(self, n):
-        return '{0}°'.format(n)
+        return '{0}º'.format(n)
 
 
 class SpanishLocale(Locale):
@@ -297,10 +297,10 @@ class SpanishLocale(Locale):
     day_names = ['', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado', 'domingo']
     day_abbreviations = ['', 'lun', 'mar', 'mie', 'jue', 'vie', 'sab', 'dom']
 
-    ordinal_day_re = r'((?P<value>[1-3]?[0-9](?=°))°)'
+    ordinal_day_re = r'((?P<value>[1-3]?[0-9](?=[ºª]))[ºª])'
 
     def _ordinal_number(self, n):
-        return '{0}°'.format(n)
+        return '{0}º'.format(n)
 
 
 class FrenchLocale(Locale):

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -102,7 +102,6 @@ class ItalianLocalesTests(Chai):
         locale = locales.ItalianLocale()
 
         assertEqual(locale.ordinal_number(1), '1º')
-        assertEqual(locale.ordinal_number(2), '2ª')
 
 
 class SpanishLocalesTests(Chai):
@@ -111,7 +110,6 @@ class SpanishLocalesTests(Chai):
         locale = locales.SpanishLocale()
 
         assertEqual(locale.ordinal_number(1), '1º')
-        assertEqual(locale.ordinal_number(2), '2ª')
 
 
 class FrenchLocalesTests(Chai):

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -101,7 +101,8 @@ class ItalianLocalesTests(Chai):
     def test_ordinal_number(self):
         locale = locales.ItalianLocale()
 
-        assertEqual(locale.ordinal_number(1), '1°')
+        assertEqual(locale.ordinal_number(1), '1º')
+        assertEqual(locale.ordinal_number(1), '2ª')
 
 
 class SpanishLocalesTests(Chai):
@@ -109,7 +110,8 @@ class SpanishLocalesTests(Chai):
     def test_ordinal_number(self):
         locale = locales.SpanishLocale()
 
-        assertEqual(locale.ordinal_number(1), '1°')
+        assertEqual(locale.ordinal_number(1), '1º')
+        assertEqual(locale.ordinal_number(1), '2ª')
 
 
 class FrenchLocalesTests(Chai):

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -102,7 +102,7 @@ class ItalianLocalesTests(Chai):
         locale = locales.ItalianLocale()
 
         assertEqual(locale.ordinal_number(1), '1º')
-        assertEqual(locale.ordinal_number(1), '2ª')
+        assertEqual(locale.ordinal_number(2), '2ª')
 
 
 class SpanishLocalesTests(Chai):
@@ -111,7 +111,7 @@ class SpanishLocalesTests(Chai):
         locale = locales.SpanishLocale()
 
         assertEqual(locale.ordinal_number(1), '1º')
-        assertEqual(locale.ordinal_number(1), '2ª')
+        assertEqual(locale.ordinal_number(2), '2ª')
 
 
 class FrenchLocalesTests(Chai):

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -646,13 +646,13 @@ class DateTimeParserMonthOrdinalDayTests(Chai):
     def test_italian(self):
         parser_ = parser.DateTimeParser('it_it')
 
-        assertEqual(parser_.parse('Gennaio 1°, 2013', 'MMMM Do, YYYY'),
+        assertEqual(parser_.parse('Gennaio 1º, 2013', 'MMMM Do, YYYY'),
                     datetime(2013, 1, 1))
 
     def test_spanish(self):
         parser_ = parser.DateTimeParser('es_es')
 
-        assertEqual(parser_.parse('Enero 1°, 2013', 'MMMM Do, YYYY'),
+        assertEqual(parser_.parse('Enero 1º, 2013', 'MMMM Do, YYYY'),
                     datetime(2013, 1, 1))
 
     def test_french(self):


### PR DESCRIPTION
According to Wikipedia: [](https://en.wikipedia.org/wiki/Ordinal_indicator#.C2.BA_and_.C2.AA)

> In Italian, Spanish, Galician and Portuguese, the suffixes º and ª are appended to the numeral depending on whether the grammatical gender is masculine or feminine respectively. º is not to be confused with the superscript lower-case o (o), the degree symbol (°), or the ring diacritic (˚); ª is not to be confused with the superscript lower-case a (a).

Before this fix, the character for masculine was incorrect and feminine was missing at all