### PR TITLE
Fix supported Python versions in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Features
 --------
 
 - Fully implemented, drop-in replacement for datetime 
-- Supports Python 2.6, 2.7 and 3.3
+- Supports Python 2.6, 2.7, 3.3, 3.4 and 3.5
 - Time zone-aware & UTC by default
 - Provides super-simple creation options for many common input scenarios
 - Updated .replace method with support for relative offsets, including weeks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Features
 --------
 
 - Fully implemented, drop-in replacement for datetime
-- Supports Python 2.6, 2.7 and 3.3
+- Supports Python 2.6, 2.7, 3.3, 3.4 and 3.5
 - Time zone-aware & UTC by default
 - Provides super-simple creation options for many common input scenarios
 - Updated .replace method with support for relative offsets, including weeks


### PR DESCRIPTION
Based on `setup.py`, versions 3.4 and 3.5 are also supported; update docs to reflect that.