### PR TITLE
return NotImplemented instead of raising TypeError

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -681,7 +681,7 @@ class Arrow(object):
         if isinstance(other, (timedelta, relativedelta)):
             return self.fromdatetime(self._datetime + other, self._datetime.tzinfo)
 
-        raise TypeError()
+        return NotImplemented
 
     def __radd__(self, other):
         return self.__add__(other)
@@ -697,21 +697,17 @@ class Arrow(object):
         elif isinstance(other, Arrow):
             return self._datetime - other._datetime
 
-        raise TypeError()
+        return NotImplemented
 
     def __rsub__(self, other):
 
         if isinstance(other, datetime):
             return other - self._datetime
 
-        raise TypeError()
+        return NotImplemented
 
 
     # comparisons
-
-    def _cmperror(self, other):
-        raise TypeError('can\'t compare \'{0}\' to \'{1}\''.format(
-            type(self), type(other)))
 
     def __eq__(self, other):
 
@@ -723,35 +719,46 @@ class Arrow(object):
         return self._datetime == self._get_datetime(other)
 
     def __ne__(self, other):
+
+        if not isinstance(other, (Arrow, datetime)):
+            return True
+
         return not self.__eq__(other)
 
     def __gt__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            self._cmperror(other)
+            return NotImplemented
 
         return self._datetime > self._get_datetime(other)
 
     def __ge__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            self._cmperror(other)
+            return NotImplemented
 
         return self._datetime >= self._get_datetime(other)
 
     def __lt__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            self._cmperror(other)
+            return NotImplemented
 
         return self._datetime < self._get_datetime(other)
 
     def __le__(self, other):
 
         if not isinstance(other, (Arrow, datetime)):
-            self._cmperror(other)
+            return NotImplemented
 
         return self._datetime <= self._get_datetime(other)
+
+    def __cmp__(self, other):
+        if sys.version_info[0] < 3: # pragma: no cover
+            if not isinstance(other, (Arrow, datetime)):
+                raise TypeError('can\'t compare \'{0}\' to \'{1}\''.format(
+                    type(self), type(other)))
+
 
 
     # datetime methods

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -272,7 +272,7 @@ class ArrowMathTests(Chai):
     def test_add_other(self):
 
         with assertRaises(TypeError):
-            self.arrow.__add__(1)
+            self.arrow + 1
 
     def test_radd(self):
 
@@ -301,7 +301,7 @@ class ArrowMathTests(Chai):
     def test_sub_other(self):
 
         with assertRaises(TypeError):
-            self.arrow.__sub__(object())
+            self.arrow - object()
 
     def test_rsub_datetime(self):
 
@@ -312,7 +312,7 @@ class ArrowMathTests(Chai):
     def test_rsub_other(self):
 
         with assertRaises(TypeError):
-            self.arrow.__rsub__(timedelta(days=1))
+            timedelta(days=1) - self.arrow
 
 
 class ArrowDatetimeInterfaceTests(Chai):


### PR DESCRIPTION
`TypeError` will already be raised by Python, if both object
implementations  don't know how to handle the other type.

This allows other classes to implement a `__rOperation__`, even
when arrow doesn't know how to handle it with `__Operation__` itself.

From the docs:

**NotImplemented:**
Special value which should be returned by the binary special methods
(e.g. `__eq__()`, `__lt__()`, `__add__()`, `__rsub__()`, etc.) to indicate that
the operation is not implemented with respect to the other type; may be
returned by the in-place binary special methods (e.g. `__imul__()`,
`__iand__()`, etc.) for the same purpose. Its truth value is `true`.

**Binary arithmetic operations:**
[...]
If one of those methods does not support the operation with the supplied
arguments, it should return `NotImplemented`.

**Rich comparison methods:**
A rich comparison method may return the singleton `NotImplemented` if it
does not implement the operation for a given pair of arguments.
