### PR TITLE
Separate replace & shift function

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -378,11 +378,6 @@ class Arrow(object):
         >>> arw.replace(year=2014, month=6)
         <Arrow [2014-06-11T22:27:34.787885+00:00]>
 
-        Use plural property names to shift their current value relatively:
-
-        >>> arw.replace(years=1, months=-1)
-        <Arrow [2014-04-11T22:27:34.787885+00:00]>
-
         You can also provide a timezone expression can also be replaced:
 
         >>> arw.replace(tzinfo=tz.tzlocal())
@@ -398,21 +393,17 @@ class Arrow(object):
         '''
 
         absolute_kwargs = {}
-        relative_kwargs = {}
 
         for key, value in kwargs.items():
 
             if key in self._ATTRS:
                 absolute_kwargs[key] = value
-            elif key in self._ATTRS_PLURAL or key == 'weeks':
-                relative_kwargs[key] = value
             elif key == 'week':
                 raise AttributeError('setting absolute week is not supported')
             elif key !='tzinfo':
                 raise AttributeError()
 
         current = self._datetime.replace(**absolute_kwargs)
-        current += relativedelta(**relative_kwargs)
 
         tzinfo = kwargs.get('tzinfo')
 
@@ -422,9 +413,37 @@ class Arrow(object):
 
         return self.fromdatetime(current)
 
+    def shift(self, **kwargs):
+        ''' Returns a new :class:`Arrow <arrow.arrow.Arrow>` object with
+        attributes updated according to inputs.
+
+        Use plural property names to shift their current value relatively:
+
+        >>> import arrow
+        >>> arw = arrow.utcnow()
+        >>> arw
+        <Arrow [2013-05-11T22:27:34.787885+00:00]>
+        >>> arw.shift(years=1, months=-1)
+        <Arrow [2014-04-11T22:27:34.787885+00:00]>
+
+        '''
+
+        relative_kwargs = {}
+
+        for key, value in kwargs.items():
+
+            if key in self._ATTRS_PLURAL or key == 'weeks':
+                relative_kwargs[key] = value
+            else:
+                raise AttributeError()
+
+        current = self._datetime + relativedelta(**relative_kwargs)
+
+        return self.fromdatetime(current)
+
     def to(self, tz):
-        ''' Returns a new :class:`Arrow <arrow.arrow.Arrow>` object, converted to the target
-        timezone.
+        ''' Returns a new :class:`Arrow <arrow.arrow.Arrow>` object, converted
+        to the target timezone.
 
         :param tz: an expression representing a timezone.
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -12,6 +12,8 @@ from dateutil import tz as dateutil_tz
 from dateutil.relativedelta import relativedelta
 import calendar
 import sys
+import warnings
+
 
 from arrow import util, locales, parser, formatter
 
@@ -383,6 +385,12 @@ class Arrow(object):
         >>> arw.replace(tzinfo=tz.tzlocal())
         <Arrow [2013-05-11T22:27:34.787885-07:00]>
 
+       NOTE: Deprecated in next release
+       Use plural property names to shift their current value relatively:
+
+       >>> arw.replace(years=1, months=-1)
+       <Arrow [2014-04-11T22:27:34.787885+00:00]>
+
         Recognized timezone expressions:
 
             - A ``tzinfo`` object.
@@ -393,17 +401,25 @@ class Arrow(object):
         '''
 
         absolute_kwargs = {}
+        relative_kwargs = {}  # TODO: DEPRECATED; remove in next release
 
         for key, value in kwargs.items():
 
             if key in self._ATTRS:
                 absolute_kwargs[key] = value
+            elif key in self._ATTRS_PLURAL or key == 'weeks':
+                # TODO: DEPRECATED
+                warnings.warn("replace() with plural property to shift value"
+                              "is deprecated, use shift() instead",
+                              DeprecationWarning)
+                relative_kwargs[key] = value
             elif key == 'week':
                 raise AttributeError('setting absolute week is not supported')
             elif key !='tzinfo':
                 raise AttributeError()
 
         current = self._datetime.replace(**absolute_kwargs)
+        current += relativedelta(**relative_kwargs) # TODO: DEPRECATED
 
         tzinfo = kwargs.get('tzinfo')
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -423,12 +423,9 @@ class Arrow(object):
                 raise AttributeError('unknown attribute: "{0}"'.format(key))
 
         # core datetime does not support quarters, translate to months.
-        if 'quarters' in relative_kwargs.keys():
-            if relative_kwargs.get('months') is None:
-                relative_kwargs['months'] = 0
-            relative_kwargs['months'] += (value * self._MONTHS_PER_QUARTER)
-            relative_kwargs.pop('quarters')
-            
+        relative_kwargs.setdefault('months', 0)
+        relative_kwargs['months'] += relative_kwargs.pop('quarters', 0) * self._MONTHS_PER_QUARTER
+
         current = self._datetime.replace(**absolute_kwargs)
         current += relativedelta(**relative_kwargs) # TODO: DEPRECATED
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -389,8 +389,7 @@ class Arrow(object):
         >>> arw.replace(tzinfo=tz.tzlocal())
         <Arrow [2013-05-11T22:27:34.787885-07:00]>
 
-       NOTE: Deprecated in next release
-       Use plural property names to shift their current value relatively:
+       Use plural property names to shift their current value relatively (**deprecated**):
 
        >>> arw.replace(years=1, months=-1)
        <Arrow [2014-04-11T22:27:34.787885+00:00]>
@@ -438,8 +437,8 @@ class Arrow(object):
         return self.fromdatetime(current)
 
     def shift(self, **kwargs):
-        ''' Returns a new :class:`Arrow <arrow.arrow.Arrow>` object with
-        attributes updated according to inputs.
+        ''' Returns a new :class:`Arrow <arrow.arrow.Arrow>` object with attributes updated
+        according to inputs.
 
         Use plural property names to shift their current value relatively:
 
@@ -456,10 +455,14 @@ class Arrow(object):
 
         for key, value in kwargs.items():
 
-            if key in self._ATTRS_PLURAL or key == 'weeks':
+            if key in self._ATTRS_PLURAL or key in ['weeks', 'quarters']:
                 relative_kwargs[key] = value
             else:
                 raise AttributeError()
+
+        # core datetime does not support quarters, translate to months.
+        relative_kwargs.setdefault('months', 0)
+        relative_kwargs['months'] += relative_kwargs.pop('quarters', 0) * self._MONTHS_PER_QUARTER
 
         current = self._datetime + relativedelta(**relative_kwargs)
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -571,8 +571,8 @@ class ArrowShiftTests(Chai):
         arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
 
         assertEqual(arw.shift(years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
-        # assertEqual(arw.shift(quarters=1), arrow.Arrow(2013, 8, 5, 12, 30, 45))
-        # assertEqual(arw.shift(quarters=1, months=1), arrow.Arrow(2013, 9, 5, 12, 30, 45))
+        assertEqual(arw.shift(quarters=1), arrow.Arrow(2013, 8, 5, 12, 30, 45))
+        assertEqual(arw.shift(quarters=1, months=1), arrow.Arrow(2013, 9, 5, 12, 30, 45))
         assertEqual(arw.shift(months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
         assertEqual(arw.shift(weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
         assertEqual(arw.shift(days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
@@ -586,8 +586,8 @@ class ArrowShiftTests(Chai):
         arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
 
         assertEqual(arw.shift(years=-1), arrow.Arrow(2012, 5, 5, 12, 30, 45))
-        # assertEqual(arw.shift(quarters=-1), arrow.Arrow(2013, 2, 5, 12, 30, 45))
-        # assertEqual(arw.shift(quarters=-1, months=-1), arrow.Arrow(2013, 1, 5, 12, 30, 45))
+        assertEqual(arw.shift(quarters=-1), arrow.Arrow(2013, 2, 5, 12, 30, 45))
+        assertEqual(arw.shift(quarters=-1, months=-1), arrow.Arrow(2013, 1, 5, 12, 30, 45))
         assertEqual(arw.shift(months=-1), arrow.Arrow(2013, 4, 5, 12, 30, 45))
         assertEqual(arw.shift(weeks=-1), arrow.Arrow(2013, 4, 28, 12, 30, 45))
         assertEqual(arw.shift(days=-1), arrow.Arrow(2013, 5, 4, 12, 30, 45))
@@ -596,21 +596,21 @@ class ArrowShiftTests(Chai):
         assertEqual(arw.shift(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
         assertEqual(arw.shift(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999))
 
-    # def test_shift_quarters_bug(self):
+    def test_shift_quarters_bug(self):
 
-    #     arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
 
-    #     # The value of the last-read argument was used instead of the ``quarters`` argument.
-    #     # Recall that the keyword argument dict, like all dicts, is unordered, so only certain
-    #     # combinations of arguments would exhibit this.
-    #     assertEqual(arw.replace(quarters=0, years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
-    #     assertEqual(arw.replace(quarters=0, months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
-    #     assertEqual(arw.replace(quarters=0, weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
-    #     assertEqual(arw.replace(quarters=0, days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
-    #     assertEqual(arw.replace(quarters=0, hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
-    #     assertEqual(arw.replace(quarters=0, minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
-    #     assertEqual(arw.replace(quarters=0, seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
-    #     assertEqual(arw.replace(quarters=0, microseconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 45, 1))
+        # The value of the last-read argument was used instead of the ``quarters`` argument.
+        # Recall that the keyword argument dict, like all dicts, is unordered, so only certain
+        # combinations of arguments would exhibit this.
+        assertEqual(arw.replace(quarters=0, years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
+        assertEqual(arw.replace(quarters=0, minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
+        assertEqual(arw.replace(quarters=0, seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
+        assertEqual(arw.replace(quarters=0, microseconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 45, 1))
 
 class ArrowRangeTests(Chai):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -511,7 +511,7 @@ class ArrowShiftTests(Chai):
     def test_not_attr(self):
 
         with assertRaises(AttributeError):
-            arrow.Arrow.utcnow().replace(abc=1)
+            arrow.Arrow.utcnow().shift(abc=1)
 
     def test_shift(self):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -7,6 +7,7 @@ from chai import Chai
 from datetime import date, datetime, timedelta
 from dateutil import tz
 import simplejson as json
+import warnings
 import calendar
 import pickle
 import time
@@ -202,6 +203,28 @@ class ArrowComparisonTests(Chai):
         assertFalse(self.arrow != self.arrow)
         assertFalse(self.arrow != self.arrow.datetime)
         assertTrue(self.arrow != 'abc')
+
+    def test_deprecated_replace(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            self.arrow.replace(weeks=1)
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert "deprecated" in str(w[-1].message)
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            self.arrow.replace(hours=1)
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert "deprecated" in str(w[-1].message)
 
     def test_gt(self):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -488,6 +488,38 @@ class ArrowReplaceTests(Chai):
         assertEqual(arw.replace(minute=1), arrow.Arrow(2013, 5, 5, 12, 1, 45))
         assertEqual(arw.replace(second=1), arrow.Arrow(2013, 5, 5, 12, 30, 1))
 
+    def test_replace_shift(self):
+
+        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+
+        # This is all scheduled for deprecation
+        assertEqual(arw.replace(years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=1), arrow.Arrow(2013, 8, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=1, months=1), arrow.Arrow(2013, 9, 5, 12, 30, 45))
+        assertEqual(arw.replace(months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
+        assertEqual(arw.replace(weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
+        assertEqual(arw.replace(days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
+        assertEqual(arw.replace(hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
+        assertEqual(arw.replace(minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
+        assertEqual(arw.replace(seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
+        assertEqual(arw.replace(microseconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 45, 1))
+
+    def test_replace_shift_negative(self):
+
+        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+
+        # This is all scheduled for deprecation
+        assertEqual(arw.replace(years=-1), arrow.Arrow(2012, 5, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=-1), arrow.Arrow(2013, 2, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=-1, months=-1), arrow.Arrow(2013, 1, 5, 12, 30, 45))
+        assertEqual(arw.replace(months=-1), arrow.Arrow(2013, 4, 5, 12, 30, 45))
+        assertEqual(arw.replace(weeks=-1), arrow.Arrow(2013, 4, 28, 12, 30, 45))
+        assertEqual(arw.replace(days=-1), arrow.Arrow(2013, 5, 4, 12, 30, 45))
+        assertEqual(arw.replace(hours=-1), arrow.Arrow(2013, 5, 5, 11, 30, 45))
+        assertEqual(arw.replace(minutes=-1), arrow.Arrow(2013, 5, 5, 12, 29, 45))
+        assertEqual(arw.replace(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
+        assertEqual(arw.replace(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999))
+
     def test_replace_tzinfo(self):
 
         arw = arrow.Arrow.utcnow().to('US/Eastern')
@@ -500,6 +532,11 @@ class ArrowReplaceTests(Chai):
 
         with assertRaises(AttributeError):
             arrow.Arrow.utcnow().replace(week=1)
+
+    def test_replace_quarter(self):
+
+        with assertRaises(AttributeError):
+            arrow.Arrow.utcnow().replace(quarter=1)
 
     def test_replace_other_kwargs(self):
 
@@ -518,18 +555,23 @@ class ArrowShiftTests(Chai):
         arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
 
         assertEqual(arw.shift(years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
+        # assertEqual(arw.shift(quarters=1), arrow.Arrow(2013, 8, 5, 12, 30, 45))
+        # assertEqual(arw.shift(quarters=1, months=1), arrow.Arrow(2013, 9, 5, 12, 30, 45))
         assertEqual(arw.shift(months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
         assertEqual(arw.shift(weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
         assertEqual(arw.shift(days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
         assertEqual(arw.shift(hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
         assertEqual(arw.shift(minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
         assertEqual(arw.shift(seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
+        assertEqual(arw.shift(microseconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 45, 1))
 
     def test_shift_negative(self):
 
         arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
 
         assertEqual(arw.shift(years=-1), arrow.Arrow(2012, 5, 5, 12, 30, 45))
+        # assertEqual(arw.shift(quarters=-1), arrow.Arrow(2013, 2, 5, 12, 30, 45))
+        # assertEqual(arw.shift(quarters=-1, months=-1), arrow.Arrow(2013, 1, 5, 12, 30, 45))
         assertEqual(arw.shift(months=-1), arrow.Arrow(2013, 4, 5, 12, 30, 45))
         assertEqual(arw.shift(weeks=-1), arrow.Arrow(2013, 4, 28, 12, 30, 45))
         assertEqual(arw.shift(days=-1), arrow.Arrow(2013, 5, 4, 12, 30, 45))
@@ -537,7 +579,6 @@ class ArrowShiftTests(Chai):
         assertEqual(arw.shift(minutes=-1), arrow.Arrow(2013, 5, 5, 12, 29, 45))
         assertEqual(arw.shift(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
         assertEqual(arw.shift(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999))
-
 
 class ArrowRangeTests(Chai):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -520,6 +520,22 @@ class ArrowReplaceTests(Chai):
         assertEqual(arw.replace(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
         assertEqual(arw.replace(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999))
 
+    def test_replace_quarters_bug(self):
+
+        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+
+        # The value of the last-read argument was used instead of the ``quarters`` argument.
+        # Recall that the keyword argument dict, like all dicts, is unordered, so only certain
+        # combinations of arguments would exhibit this.
+        assertEqual(arw.replace(quarters=0, years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
+        assertEqual(arw.replace(quarters=0, hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
+        assertEqual(arw.replace(quarters=0, minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
+        assertEqual(arw.replace(quarters=0, seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
+        assertEqual(arw.replace(quarters=0, microseconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 45, 1))
+
     def test_replace_tzinfo(self):
 
         arw = arrow.Arrow.utcnow().to('US/Eastern')
@@ -579,6 +595,22 @@ class ArrowShiftTests(Chai):
         assertEqual(arw.shift(minutes=-1), arrow.Arrow(2013, 5, 5, 12, 29, 45))
         assertEqual(arw.shift(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
         assertEqual(arw.shift(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999))
+
+    # def test_shift_quarters_bug(self):
+
+    #     arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+
+    #     # The value of the last-read argument was used instead of the ``quarters`` argument.
+    #     # Recall that the keyword argument dict, like all dicts, is unordered, so only certain
+    #     # combinations of arguments would exhibit this.
+    #     assertEqual(arw.replace(quarters=0, years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
+    #     assertEqual(arw.replace(quarters=0, months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
+    #     assertEqual(arw.replace(quarters=0, weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
+    #     assertEqual(arw.replace(quarters=0, days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
+    #     assertEqual(arw.replace(quarters=0, hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
+    #     assertEqual(arw.replace(quarters=0, minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
+    #     assertEqual(arw.replace(quarters=0, seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
+    #     assertEqual(arw.replace(quarters=0, microseconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 45, 1))
 
 class ArrowRangeTests(Chai):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -205,7 +205,7 @@ class ArrowComparisonTests(Chai):
 
     def test_gt(self):
 
-        arrow_cmp = self.arrow.replace(minutes=1)
+        arrow_cmp = self.arrow.shift(minutes=1)
 
         assertFalse(self.arrow > self.arrow)
         assertFalse(self.arrow > self.arrow.datetime)
@@ -226,7 +226,7 @@ class ArrowComparisonTests(Chai):
 
     def test_lt(self):
 
-        arrow_cmp = self.arrow.replace(minutes=1)
+        arrow_cmp = self.arrow.shift(minutes=1)
 
         assertFalse(self.arrow < self.arrow)
         assertFalse(self.arrow < self.arrow.datetime)
@@ -440,7 +440,7 @@ class ArrowReplaceTests(Chai):
         with assertRaises(AttributeError):
             arrow.Arrow.utcnow().replace(abc=1)
 
-    def test_replace_absolute(self):
+    def test_replace(self):
 
         arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
 
@@ -450,32 +450,6 @@ class ArrowReplaceTests(Chai):
         assertEqual(arw.replace(hour=1), arrow.Arrow(2013, 5, 5, 1, 30, 45))
         assertEqual(arw.replace(minute=1), arrow.Arrow(2013, 5, 5, 12, 1, 45))
         assertEqual(arw.replace(second=1), arrow.Arrow(2013, 5, 5, 12, 30, 1))
-
-    def test_replace_relative(self):
-
-        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
-
-        assertEqual(arw.replace(years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
-        assertEqual(arw.replace(months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
-        assertEqual(arw.replace(weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
-        assertEqual(arw.replace(days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
-        assertEqual(arw.replace(hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
-        assertEqual(arw.replace(minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
-        assertEqual(arw.replace(seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
-
-    def test_replace_relative_negative(self):
-
-        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
-
-        assertEqual(arw.replace(years=-1), arrow.Arrow(2012, 5, 5, 12, 30, 45))
-        assertEqual(arw.replace(months=-1), arrow.Arrow(2013, 4, 5, 12, 30, 45))
-        assertEqual(arw.replace(weeks=-1), arrow.Arrow(2013, 4, 28, 12, 30, 45))
-        assertEqual(arw.replace(days=-1), arrow.Arrow(2013, 5, 4, 12, 30, 45))
-        assertEqual(arw.replace(hours=-1), arrow.Arrow(2013, 5, 5, 11, 30, 45))
-        assertEqual(arw.replace(minutes=-1), arrow.Arrow(2013, 5, 5, 12, 29, 45))
-        assertEqual(arw.replace(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
-        assertEqual(arw.replace(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999))
-
 
     def test_replace_tzinfo(self):
 
@@ -494,6 +468,38 @@ class ArrowReplaceTests(Chai):
 
         with assertRaises(AttributeError):
             arrow.utcnow().replace(abc='def')
+
+class ArrowShiftTests(Chai):
+
+    def test_not_attr(self):
+
+        with assertRaises(AttributeError):
+            arrow.Arrow.utcnow().replace(abc=1)
+
+    def test_shift(self):
+
+        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+
+        assertEqual(arw.shift(years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
+        assertEqual(arw.shift(months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
+        assertEqual(arw.shift(weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
+        assertEqual(arw.shift(days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
+        assertEqual(arw.shift(hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
+        assertEqual(arw.shift(minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
+        assertEqual(arw.shift(seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
+
+    def test_shift_negative(self):
+
+        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+
+        assertEqual(arw.shift(years=-1), arrow.Arrow(2012, 5, 5, 12, 30, 45))
+        assertEqual(arw.shift(months=-1), arrow.Arrow(2013, 4, 5, 12, 30, 45))
+        assertEqual(arw.shift(weeks=-1), arrow.Arrow(2013, 4, 28, 12, 30, 45))
+        assertEqual(arw.shift(days=-1), arrow.Arrow(2013, 5, 4, 12, 30, 45))
+        assertEqual(arw.shift(hours=-1), arrow.Arrow(2013, 5, 5, 11, 30, 45))
+        assertEqual(arw.shift(minutes=-1), arrow.Arrow(2013, 5, 5, 12, 29, 45))
+        assertEqual(arw.shift(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
+        assertEqual(arw.shift(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999))
 
 
 class ArrowRangeTests(Chai):
@@ -909,7 +915,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_seconds(self):
 
-        later = self.now.replace(seconds=10)
+        later = self.now.shift(seconds=10)
 
         assertEqual(self.now.humanize(later), 'seconds ago')
         assertEqual(later.humanize(self.now), 'in seconds')
@@ -919,7 +925,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_minute(self):
 
-        later = self.now.replace(minutes=1)
+        later = self.now.shift(minutes=1)
 
         assertEqual(self.now.humanize(later), 'a minute ago')
         assertEqual(later.humanize(self.now), 'in a minute')
@@ -930,7 +936,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_minutes(self):
 
-        later = self.now.replace(minutes=2)
+        later = self.now.shift(minutes=2)
 
         assertEqual(self.now.humanize(later), '2 minutes ago')
         assertEqual(later.humanize(self.now), 'in 2 minutes')
@@ -940,7 +946,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_hour(self):
 
-        later = self.now.replace(hours=1)
+        later = self.now.shift(hours=1)
 
         assertEqual(self.now.humanize(later), 'an hour ago')
         assertEqual(later.humanize(self.now), 'in an hour')
@@ -950,7 +956,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_hours(self):
 
-        later = self.now.replace(hours=2)
+        later = self.now.shift(hours=2)
 
         assertEqual(self.now.humanize(later), '2 hours ago')
         assertEqual(later.humanize(self.now), 'in 2 hours')
@@ -960,7 +966,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_day(self):
 
-        later = self.now.replace(days=1)
+        later = self.now.shift(days=1)
 
         assertEqual(self.now.humanize(later), 'a day ago')
         assertEqual(later.humanize(self.now), 'in a day')
@@ -970,7 +976,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_days(self):
 
-        later = self.now.replace(days=2)
+        later = self.now.shift(days=2)
 
         assertEqual(self.now.humanize(later), '2 days ago')
         assertEqual(later.humanize(self.now), 'in 2 days')
@@ -980,7 +986,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_month(self):
 
-        later = self.now.replace(months=1)
+        later = self.now.shift(months=1)
 
         assertEqual(self.now.humanize(later), 'a month ago')
         assertEqual(later.humanize(self.now), 'in a month')
@@ -990,7 +996,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_months(self):
 
-        later = self.now.replace(months=2)
+        later = self.now.shift(months=2)
 
         assertEqual(self.now.humanize(later), '2 months ago')
         assertEqual(later.humanize(self.now), 'in 2 months')
@@ -1000,7 +1006,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_year(self):
 
-        later = self.now.replace(years=1)
+        later = self.now.shift(years=1)
 
         assertEqual(self.now.humanize(later), 'a year ago')
         assertEqual(later.humanize(self.now), 'in a year')
@@ -1010,7 +1016,7 @@ class ArrowHumanizeTests(Chai):
 
     def test_years(self):
 
-        later = self.now.replace(years=2)
+        later = self.now.shift(years=2)
 
         assertEqual(self.now.humanize(later), '2 years ago')
         assertEqual(later.humanize(self.now), 'in 2 years')


### PR DESCRIPTION
This resolves the merge conflicts from https://github.com/crsmithdev/arrow/pull/276.  It also fixes (in https://github.com/crsmithdev/arrow/pull/349/commits/b5eee6ddf91f6479309a8597f3052a0f8ffa37a0) a bug in the `quarters` functionality, adds `quarters` to `shift`, and gets back to 100% code coverage.

Separating replace and shift functionality would save a lot of headaches!
