### PR TITLE
respect limit even if end is defined in a range

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -898,7 +898,9 @@ class Arrow(object):
             return cls.max, limit
 
         else:
-            return end, sys.maxsize
+            if limit is None:
+                return end, sys.maxsize
+            return end, limit
 
     @staticmethod
     def _get_timestamp_from_input(timestamp):

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1151,6 +1151,7 @@ class ArrowUtilTests(Chai):
 
         assertEqual(arrow.Arrow._get_iteration_params('end', None), ('end', sys.maxsize))
         assertEqual(arrow.Arrow._get_iteration_params(None, 100), (arrow.Arrow.max, 100))
+        assertEqual(arrow.Arrow._get_iteration_params(100, 120), (100, 120))
 
         with assertRaises(Exception):
             arrow.Arrow._get_iteration_params(None, None)


### PR DESCRIPTION
I was reading the docs and I think this was the intended behaviour. If this is alright, I'll add some tests.
