### PR TITLE
Add support for universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ cover-package = arrow
 cover-erase = true
 cover-inclusive = true
 cover-branches = true
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Since arrow is a pure python module which support python 2 and 3 with the same code, it can be put in a universal wheel.