### PR TITLE
Fix negative offset for UTC

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -94,7 +94,7 @@ class DateTimeFormatter(object):
             tz = dateutil_tz.tzutc() if dt.tzinfo is None else dt.tzinfo
             total_minutes = int(util.total_seconds(tz.utcoffset(dt)) / 60)
 
-            sign = '+' if total_minutes > 0 else '-'
+            sign = '+' if total_minutes >= 0 else '-'
             total_minutes = abs(total_minutes)
             hour, minute = divmod(total_minutes, 60)
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -129,7 +129,7 @@ class ArrowRepresentationTests(Chai):
 
         result = self.arrow.format()
 
-        assertEqual(result, '2013-02-03 12:30:45-00:00')
+        assertEqual(result, '2013-02-03 12:30:45+00:00')
 
     def test_format_no_format_string(self):
 


### PR DESCRIPTION
Specifying ZZ in a format string gives an offest of -00:00 for UTC,
despite the arrow object repr showing +00:00. Detect `using >= 0`
for consistency.