### PR TITLE
Fixes #378: __getattr__ has an off-by-one error in its quarter handling

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -310,7 +310,7 @@ class Arrow(object):
             return self.isocalendar()[1]
 
         if name == 'quarter':
-            return int(self.month/self._MONTHS_PER_QUARTER) + 1
+            return int((self.month-1)/self._MONTHS_PER_QUARTER) + 1
 
         if not name.startswith('_'):
             value = getattr(self._datetime, name, None)

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -162,10 +162,21 @@ class ArrowAttributeTests(Chai):
         assertEqual(self.arrow.week, 1)
 
     def test_getattr_quarter(self):
+        # start dates
         q1 = arrow.Arrow(2013, 1, 1)
         q2 = arrow.Arrow(2013, 4, 1)
         q3 = arrow.Arrow(2013, 8, 1)
         q4 = arrow.Arrow(2013, 10, 1)
+        assertEqual(q1.quarter, 1)
+        assertEqual(q2.quarter, 2)
+        assertEqual(q3.quarter, 3)
+        assertEqual(q4.quarter, 4)
+
+        # end dates
+        q1 = arrow.Arrow(2013, 3, 31)
+        q2 = arrow.Arrow(2013, 6, 30)
+        q3 = arrow.Arrow(2013, 9, 30)
+        q4 = arrow.Arrow(2013, 12, 31)
         assertEqual(q1.quarter, 1)
         assertEqual(q2.quarter, 2)
         assertEqual(q3.quarter, 3)


### PR DESCRIPTION
Fixes issue https://github.com/crsmithdev/arrow/issues/378

I added test cases for quarter end dates to make sure they were being included in the correct quarter (as well as a fix).