### PR TITLE
Cached compiled format strings to speed up repetitive parsing

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -8,8 +8,8 @@ import re
 
 try:
     from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache
+except ImportError:  # pragma: no cover
+    from backports.functools_lru_cache import lru_cache  # pragma: no cover
 
 from arrow import locales
 

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -128,7 +128,7 @@ class DateTimeParser(object):
         offset = 0
 
         # Extract the bracketed expressions to be reinserted later.
-        escaped_fmt = re.sub(self._ESCAPE_RE, "#" , fmt)
+        escaped_fmt = re.sub(self._ESCAPE_RE, "#", fmt)
         # Any number of S is the same as one.
         escaped_fmt = re.sub('S+', 'S', escaped_fmt)
         escaped_data = re.findall(self._ESCAPE_RE, fmt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-python-dateutil==2.1
+python-dateutil==2.6.0
 nose==1.3.0
 nose-cov==1.6
-chai==0.4.8
+chai==1.1.1
 sphinx==1.2b1
 simplejson==3.6.5
 backports.functools_lru_cache==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ nose-cov==1.6
 chai==0.4.8
 sphinx==1.2b1
 simplejson==3.6.5
+backports.functools_lru_cache==1.2.1

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -60,42 +60,41 @@ class DateTimeParserTests(Chai):
         assertEqual(parts, {})
 
     def test_parser_no_caching(self):
-        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(100)
 
+        expect(parser.DateTimeParser, '_generate_pattern_re').args('fmt_a').times(100)
         self.parser = parser.DateTimeParser(cache_size=0)
-
         for _ in range(100):
             self.parser._generate_pattern_re('fmt_a')
 
     def test_parser_1_line_caching(self):
 
-        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(1)
+        expect(parser.DateTimeParser, '_generate_pattern_re').args('fmt_a').times(1)
         self.parser = parser.DateTimeParser(cache_size=1)
         for _ in range(100):
             self.parser._generate_pattern_re('fmt_a')
 
-        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_b').times(1)
+        expect(parser.DateTimeParser, '_generate_pattern_re').args('fmt_b').times(1)
         for _ in range(100):
             self.parser._generate_pattern_re('fmt_a')
         self.parser._generate_pattern_re('fmt_b')
 
-        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(1)
+        expect(parser.DateTimeParser, '_generate_pattern_re').args('fmt_a').times(1)
         for _ in range(100):
             self.parser._generate_pattern_re('fmt_a')
 
     def test_parser_multiple_line_caching(self):
 
-        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(1)
+        expect(parser.DateTimeParser, '_generate_pattern_re').args('fmt_a').times(1)
         self.parser = parser.DateTimeParser(cache_size=2)
         for _ in range(100):
             self.parser._generate_pattern_re('fmt_a')
 
-        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_b').times(1)
+        expect(parser.DateTimeParser, '_generate_pattern_re').args('fmt_b').times(1)
         for _ in range(100):
             self.parser._generate_pattern_re('fmt_a')
         self.parser._generate_pattern_re('fmt_b')
 
-        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(0)
+        expect(parser.DateTimeParser, '_generate_pattern_re').args('fmt_a').times(0)
         for _ in range(100):
             self.parser._generate_pattern_re('fmt_a')
 

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -59,6 +59,45 @@ class DateTimeParserTests(Chai):
         self.parser._parse_token('a', 'p..m', parts)
         assertEqual(parts, {})
 
+    def test_parser_no_caching(self):
+        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(100)
+
+        self.parser = parser.DateTimeParser(cache_size=0)
+
+        for _ in range(100):
+            self.parser._generate_pattern_re('fmt_a')
+
+    def test_parser_1_line_caching(self):
+
+        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(1)
+        self.parser = parser.DateTimeParser(cache_size=1)
+        for _ in range(100):
+            self.parser._generate_pattern_re('fmt_a')
+
+        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_b').times(1)
+        for _ in range(100):
+            self.parser._generate_pattern_re('fmt_a')
+        self.parser._generate_pattern_re('fmt_b')
+
+        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(1)
+        for _ in range(100):
+            self.parser._generate_pattern_re('fmt_a')
+
+    def test_parser_multiple_line_caching(self):
+
+        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(1)
+        self.parser = parser.DateTimeParser(cache_size=2)
+        for _ in range(100):
+            self.parser._generate_pattern_re('fmt_a')
+
+        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_b').times(1)
+        for _ in range(100):
+            self.parser._generate_pattern_re('fmt_a')
+        self.parser._generate_pattern_re('fmt_b')
+
+        expect(parser.DateTimeParser._generate_pattern_re).args('fmt_a').times(0)
+        for _ in range(100):
+            self.parser._generate_pattern_re('fmt_a')
 
 
 class DateTimeParserParseTests(Chai):


### PR DESCRIPTION
This PR improves the performance of `arrow.parser.DateTimeParser` by caching compiled regular expressions in an LRU cache of configurable size. By default, it is set to 0 (disabled).

This cuts parsing speed by approximately two thirds, which can be significant when parsing very large data sets.

```python
In [1]: import timeit
   ...: 
   ...: setup = """\
   ...: from arrow.parser import DateTimeParser
   ...: 
   ...: parser = DateTimeParser('en_us', cache_size=%s)
   ...: format = "dddd, MMMM D, YYYY [at] h:mmA"
   ...: string = "Friday, December 14, 2015 at 1:03pm PDT"
   ...: """
   ...: 
   ...: test_function = "parser.parse(string, format)"
   ...: 
   ...: without_cache = timeit.timeit(stmt=test_function, setup=setup % 0, number=1000000)
   ...: print("Time to process without cache: %s" % without_cache)
   ...: 
   ...: with_cache = timeit.timeit(stmt=test_function, setup=setup % 1, number=1000000)
   ...: print("Time to process with cache: %s" % with_cache)
   ...: 
Time to process without cache: 28.7442018986
Time to process with cache: 10.7125990391
```

Here is performance without these changes, just to ensure adding the LRU cache didn't incur a performance hit in itself:

```python
In [2]: import timeit
   ...: 
   ...: setup = """\
   ...: from arrow.parser import DateTimeParser
   ...: 
   ...: parser = DateTimeParser('en_us')
   ...: format = "dddd, MMMM D, YYYY [at] h:mmA"
   ...: string = "Friday, December 14, 2015 at 1:03pm PDT"
   ...: """
   ...: 
   ...: test_function = "parser.parse(string, format)"
   ...: 
   ...: without_cache = timeit.timeit(stmt=test_function, setup=setup, number=1000000)
   ...: print("Current time to process: %s" % without_cache)
   ...: 
Current time to process: 28.8488280773
```

Doesn't affect the likely more typical `arrow.get(...)` usage for parsing, but allows for more optimization by those who want it.

Only downside is it requires a backported `lru_cache` library to support Python 2.6 and 2.7, which fortunately, is tiny and doesn't have any dependencies of its own.