### PR TITLE
Adjustable Start Index for Spans (Per Issue #355)

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -527,7 +527,7 @@ class Arrow(object):
         return self.__class__(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
             dt.microsecond, dt.tzinfo)
 
-    def span(self, frame, count=1):
+    def span(self, frame, count=1, start_index=0):
         ''' Returns two new :class:`Arrow <arrow.arrow.Arrow>` objects, representing the timespan
         of the :class:`Arrow <arrow.arrow.Arrow>` object in a given timeframe.
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -618,18 +618,25 @@ class Arrow(object):
         months       = 0
         years        = 0
 
+        if start_index != -1 and frame_absolute == 'quarter':
+            raise ValueError, "Start Index not supported with quarter"
+
+        if ((frame_absolute == 'second' and start_index not in microseconds_range) or
+            (frame_absolute == 'minute' and start_index not in seconds_range) or 
+            (frame_absolute == 'hour'   and start_index not in minutes_range) or 
+            (frame_absolute == 'day'    and start_index not in hours_range) or 
+            (frame_absolute == 'week'   and start_index not in weekdays_range) or 
+            (frame_absolute == 'month'  and start_index not in days_of_month_range) or 
+            (frame_absolute == 'year'   and start_index not in months_range)):
+            raise ValueError, "Start Index out of bounds"
 
         if frame_absolute == 'second' and start_index != -1:
-            if start_index not in microseconds_range:
-                raise ValueError, "start index out of bounds"
 
             microseconds = -(microseconds_in_second - start_index)
             if start_index <= self.microsecond:
                 seconds = 1
 
         elif frame_absolute == 'minute' and start_index != -1:
-            if start_index not in seconds_range:
-                raise ValueError, "start index out of bounds"
 
             seconds = -(seconds_in_minute - start_index)
             
@@ -637,24 +644,18 @@ class Arrow(object):
                 minutes = 1
         
         elif frame_absolute == 'hour' and start_index != -1:
-            if start_index not in minutes_range:
-                raise ValueError, "start index out of bounds"
 
             minutes = -(minutes_in_hour - start_index)
             if start_index <= self.minute:
                 hours = 1
             
         elif frame_absolute == 'day' and start_index != -1:
-            if start_index not in hours_range:
-                raise ValueError, "start index out of bounds"
 
             hours = -(hours_in_day - start_index)
             if start_index <= self.hour:
                 days = 1
 
         elif frame_absolute == 'week':
-            if start_index not in weekdays_range:
-                raise ValueError, "start_index out of bounds"
             
             if start_index == -1:
                 start_index = 0
@@ -663,8 +664,6 @@ class Arrow(object):
             days = -((self.weekday() - start_index) % 7)
 
         elif frame_absolute == 'month' and start_index != -1:
-            if start_index not in days_of_month_range:
-                raise ValueError, "start index out of bounds"
 
             days = -(days_in_month - start_index)
             if start_index <= self.day:
@@ -673,14 +672,10 @@ class Arrow(object):
                 days += days_in_month - calendar.monthrange(self.year, self.month-1)[1]
 
         elif frame_absolute == 'quarter':            
-            if start_index not in months_range and start_index != -1:
-                raise ValueError, "Start Index not supported with quarter"
 
             months = -((self.month - 1) % 3)
 
         elif frame_absolute == 'year' and start_index != -1:
-            if start_index not in months_range:
-                raise ValueError, "start index out of bound"
 
             months = -(months_in_year - start_index)
             if start_index <= self.month - 1:

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -619,7 +619,7 @@ class Arrow(object):
         years        = 0
 
         if start_index != -1 and frame_absolute == 'quarter':
-            raise ValueError, "Start Index not supported with quarter"
+            raise ValueError("Start Index not supported with quarter")
 
         if ((frame_absolute == 'second' and start_index not in microseconds_range) or
             (frame_absolute == 'minute' and start_index not in seconds_range) or 
@@ -628,7 +628,7 @@ class Arrow(object):
             (frame_absolute == 'week'   and start_index not in weekdays_range) or 
             (frame_absolute == 'month'  and start_index not in days_of_month_range) or 
             (frame_absolute == 'year'   and start_index not in months_range)):
-            raise ValueError, "Start Index out of bounds"
+            raise ValueError("Start Index out of bounds")
 
         if frame_absolute == 'second' and start_index != -1:
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1063,14 +1063,14 @@ class ArrowSpanTests(Chai):
 
     def test_span_week_with_start_index(self):
 
-        for i in xrange(5):
+        for i in range(5):
 
             floor, ceil = self.arrow.span('week', start_index=i)
 
             assertEqual(floor, datetime(2013, 2, 11+i, tzinfo=tz.tzutc()))
             assertEqual(ceil, datetime(2013, 2, 17+i, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
 
-        for i in xrange(2):
+        for i in range(2):
             k = i + 5
 
             floor, ceil = self.arrow.span('week', start_index=k)

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -964,7 +964,61 @@ class ArrowSpanTests(Chai):
         self.test_span_minute_with_start_index()
         self.test_span_second_with_start_index()  
         self.test_span_microsecond_with_start_index()
+        self.test_span_index_out_of_bounds()
+
+
+    def test_span_index_out_of_bounds(self):
+
+        # Test microsecond indices
+        with assertRaises(ValueError):
+            self.arrow.span('second', start_index=-2)
+        with assertRaises(ValueError):
+            self.arrow.span('second', start_index=1000000)
+
+
+        # Test second indices
+        with assertRaises(ValueError):
+            self.arrow.span('minute', start_index=-2)
+        with assertRaises(ValueError):
+            self.arrow.span('minute', start_index=60)
+
+
+        # Test minute indices
+        with assertRaises(ValueError):
+            self.arrow.span('hour', start_index=-2)
+        with assertRaises(ValueError):
+            self.arrow.span('hour', start_index=60)
         
+
+        # Test hour indices
+        with assertRaises(ValueError):
+            self.arrow.span('day', start_index=-2)
+        with assertRaises(ValueError):
+            self.arrow.span('day', start_index=24)
+
+
+
+        # Test day of week indices
+        with assertRaises(ValueError):
+            self.arrow.span('week', start_index=-2)
+        with assertRaises(ValueError):
+            self.arrow.span('week', start_index=7)
+        
+
+        # Test day of month indices
+        with assertRaises(ValueError):
+            self.arrow.span('month', start_index=-2)
+        with assertRaises(ValueError):
+            # Feb 2013 has 28 days
+            self.arrow.span('month', start_index=28)
+
+
+        # Test months indices
+        with assertRaises(ValueError):
+            self.arrow.span('year', start_index=-2)
+        with assertRaises(ValueError):
+            # Feb 2013 has 28 days
+            self.arrow.span('year', start_index=12)
 
 
     def test_span_year_with_start_index(self):

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -932,6 +932,164 @@ class ArrowSpanTests(Chai):
         self.datetime = datetime(2013, 2, 15, 3, 41, 22, 8923)
         self.arrow = arrow.Arrow.fromdatetime(self.datetime)
 
+    def runTest(self):
+        self.test_start_index()
+
+    def test_start_index(self):
+        '''
+        check against implementations w/o test_start_index
+        '''
+        self.test_span_year()
+        self.test_span_year_count()
+        self.test_span_month()
+        self.test_span_quarter()
+        self.test_span_quarter_count()
+        self.test_span_week()
+        self.test_span_day()
+        self.test_span_hour()
+        self.test_span_minute()
+        self.test_span_second()
+        self.test_span_microsecond()
+
+
+        '''
+        check new tests with start indexes
+        '''
+        self.test_span_year_with_start_index()
+        
+        self.test_span_year_count_with_start_index()
+        
+        self.test_span_month_with_start_index()
+        
+        self.test_span_week_with_start_index()
+        
+        self.test_span_day_with_start_index()
+        
+        self.test_span_hour_with_start_index()
+        
+        self.test_span_minute_with_start_index()
+        
+        self.test_span_second_with_start_index()
+        
+        self.test_span_microsecond_with_start_index()
+        
+
+
+    def test_span_year_with_start_index(self):
+
+        floor, ceil = self.arrow.span('year', start_index=1)
+
+        assertEqual(floor, datetime(2013, 2, 1, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2014, 1, 31, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+        floor, ceil = self.arrow.span('year', start_index=2)
+
+        assertEqual(floor, datetime(2012, 3, 1, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 28, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+
+    def test_span_year_count_with_start_index(self):
+
+        floor, ceil = self.arrow.span('year', 2, start_index=1)
+
+        assertEqual(floor, datetime(2013, 2, 1, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2015, 1, 31, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+        floor, ceil = self.arrow.span('year', 2, start_index=2)
+
+        assertEqual(floor, datetime(2012, 3, 1, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2014, 2, 28, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+
+    def test_span_month_with_start_index(self):
+
+        floor, ceil = self.arrow.span('month', start_index=12)
+
+
+        assertEqual(floor, datetime(2013, 2, 13, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 3, 12, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+        floor, ceil = self.arrow.span('month', start_index=17)
+
+        assertEqual(floor, datetime(2013, 1, 18, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 17, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+    def test_span_week_with_start_index(self):
+
+        for i in xrange(5):
+
+            floor, ceil = self.arrow.span('week', start_index=i)
+
+            assertEqual(floor, datetime(2013, 2, 11+i, tzinfo=tz.tzutc()))
+            assertEqual(ceil, datetime(2013, 2, 17+i, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+        for i in xrange(2):
+            k = i + 5
+
+            floor, ceil = self.arrow.span('week', start_index=k)
+
+            assertEqual(floor, datetime(2013, 2, 9+i, tzinfo=tz.tzutc()))
+            assertEqual(ceil, datetime(2013, 2, 15+i, 23, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+    def test_span_day_with_start_index(self):
+
+        floor, ceil = self.arrow.span('day', start_index=3)
+
+        assertEqual(floor, datetime(2013, 2, 15, 3, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 16, 2, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+
+        floor, ceil = self.arrow.span('day', start_index=4)
+
+        assertEqual(floor, datetime(2013, 2, 14, 4, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 3, 59, 59, 999999, tzinfo=tz.tzutc()))
+
+    def test_span_hour_with_start_index(self):
+
+        floor, ceil = self.arrow.span('hour', start_index=40)
+
+        assertEqual(floor, datetime(2013, 2, 15, 3, 40, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 4, 39, 59, 999999, tzinfo=tz.tzutc()))
+
+        floor, ceil = self.arrow.span('hour', start_index=50)
+
+        assertEqual(floor, datetime(2013, 2, 15, 2, 50, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 3, 49, 59, 999999, tzinfo=tz.tzutc()))
+    
+    def test_span_minute_with_start_index(self):
+
+        floor, ceil = self.arrow.span('minute', start_index=21)
+
+        assertEqual(floor, datetime(2013, 2, 15, 3, 41, 21, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 3, 42, 20, 999999, tzinfo=tz.tzutc()))
+
+        floor, ceil = self.arrow.span('minute', start_index=23)
+
+        assertEqual(floor, datetime(2013, 2, 15, 3, 40, 23, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 3, 41, 22, 999999, tzinfo=tz.tzutc()))
+
+    def test_span_second_with_start_index(self):
+
+        floor, ceil = self.arrow.span('second', start_index=8000)
+
+        assertEqual(floor, datetime(2013, 2, 15, 3, 41, 22, 8000, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 3, 41, 23, 7999, tzinfo=tz.tzutc()))
+
+
+
+        floor, ceil = self.arrow.span('second', start_index=9000)
+
+        assertEqual(floor, datetime(2013, 2, 15, 3, 41, 21, 9000, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 3, 41, 22, 8999, tzinfo=tz.tzutc()))
+
+    def test_span_microsecond_with_start_index(self):
+
+        floor, ceil = self.arrow.span('microsecond')
+
+        assertEqual(floor, datetime(2013, 2, 15, 3, 41, 22, 8923, tzinfo=tz.tzutc()))
+        assertEqual(ceil, datetime(2013, 2, 15, 3, 41, 22, 8923, tzinfo=tz.tzutc()))
+
+
     def test_span_attribute(self):
 
         with assertRaises(AttributeError):
@@ -1266,3 +1424,4 @@ class ArrowUtilTests(Chai):
 
         with assertRaises(Exception):
             arrow.Arrow._get_iteration_params(None, None)
+

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -965,7 +965,11 @@ class ArrowSpanTests(Chai):
         self.test_span_second_with_start_index()  
         self.test_span_microsecond_with_start_index()
         self.test_span_index_out_of_bounds()
+        self.test_span_no_start_index_for_quarter()
 
+    def test_span_no_start_index_for_quarter(self):
+        with assertRaises(ValueError):
+            self.arrow.span('quarter', start_index=1)
 
     def test_span_index_out_of_bounds(self):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -956,21 +956,13 @@ class ArrowSpanTests(Chai):
         check new tests with start indexes
         '''
         self.test_span_year_with_start_index()
-        
         self.test_span_year_count_with_start_index()
-        
         self.test_span_month_with_start_index()
-        
         self.test_span_week_with_start_index()
-        
         self.test_span_day_with_start_index()
-        
         self.test_span_hour_with_start_index()
-        
         self.test_span_minute_with_start_index()
-        
-        self.test_span_second_with_start_index()
-        
+        self.test_span_second_with_start_index()  
         self.test_span_microsecond_with_start_index()
         
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -932,9 +932,6 @@ class ArrowSpanTests(Chai):
         self.datetime = datetime(2013, 2, 15, 3, 41, 22, 8923)
         self.arrow = arrow.Arrow.fromdatetime(self.datetime)
 
-    def runTest(self):
-        self.test_start_index()
-
     def test_start_index(self):
         '''
         check against implementations w/o test_start_index


### PR DESCRIPTION
This commit addresses git issue 355 (https://github.com/crsmithdev/arrow/issues/355).  In addition to providing the ability to give a start index for a weekday, it also allows a user to give a start index for all spans but quarters.  For example, you could create a span of a month starting on the 7th of the month.