### PR TITLE
Added support for ZZZ while formatting

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -9,7 +9,7 @@ from arrow import util, locales
 
 class DateTimeFormatter(object):
 
-    _FORMAT_RE = re.compile('(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?|a|A|X)')
+    _FORMAT_RE = re.compile('(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X)')
 
     def __init__(self, locale='en_us'):
 
@@ -88,6 +88,9 @@ class DateTimeFormatter(object):
 
         if token == 'X':
             return str(calendar.timegm(dt.utctimetuple()))
+
+        if token == 'ZZZ':
+            return dt.tzname()
 
         if token in ['ZZ', 'Z']:
             separator = ':' if token == 'ZZ' else ''

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -4,6 +4,7 @@ from arrow import formatter
 
 from datetime import datetime
 from dateutil import tz as dateutil_tz
+import pytz
 import time
 
 class DateTimeFormatterFormatTokenTests(Chai):
@@ -117,6 +118,21 @@ class DateTimeFormatterFormatTokenTests(Chai):
 
         result = self.formatter._format_token(dt, 'Z')
         assertTrue(result == '-0700' or result == '-0800')
+
+    def test_timezone_formatter(self):
+
+        tz_map = {
+            'BRST': 'America/Sao_Paulo',
+            'CET': 'Europe/Berlin',
+            'JST': 'Asia/Tokyo',
+            'PST': 'US/Pacific',
+        }
+
+        for abbreviation, full_name in tz_map.items():
+            # This test will fail if we use "now" as date as soon as we change from/to DST
+            dt = datetime(1986, 2, 14, tzinfo=pytz.timezone('UTC')).replace(tzinfo=dateutil_tz.gettz(full_name))
+            result = self.formatter._format_token(dt, 'ZZZ')
+            assertEqual(result, abbreviation)
 
     def test_am_pm(self):
 


### PR DESCRIPTION
This fixes #390, although I am not entirely happy that `ZZZ` will parse `America/Sao_Paulo` and format as `BRT`, I could not find a reliable way to return `America/Sao_Paulo` from things like `-0300` and `BRT`.