### PR TITLE
Fix for poperly handle tz passed in from pytz

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -116,7 +116,7 @@ class Arrow(object):
         dt = datetime.fromtimestamp(timestamp, tzinfo)
 
         return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
-            dt.microsecond, tzinfo)
+            dt.microsecond, dt.tzinfo)
 
     @classmethod
     def utcfromtimestamp(cls, timestamp):


### PR DESCRIPTION
Previously:
arrow.Arrow.fromtimestamp(0, pytz.timezone('Europe/Paris'))
# <Arrow [1970-01-01T01:00:00+00:09]>
Now:
arrow.Arrow.fromtimestamp(0, pytz.timezone('Europe/Paris'))
# <Arrow [1970-01-01T01:00:00+1:00]>