### PR TITLE
Remove `timeframes['days']` handling from `AustriaLocale`

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -844,9 +844,6 @@ class AustriaLocale(_DeutschLocaleCommonMixin, Locale):
 
     names = ['de_at']
 
-    timeframes = _DeutschLocaleCommonMixin.timeframes.copy()
-    timeframes['days'] = '{0} Tage'
-
 
 class NorwegianLocale(Locale):
 


### PR DESCRIPTION
According to this [German SE answer](http://german.stackexchange.com/a/34107/25165) the special case for `timeframes['days']` in `AustriaLocale` is wrong.