### PR TITLE
ArrowFactory.get: document kwargs locale and tzinfo

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -32,6 +32,12 @@ class ArrowFactory(object):
     def get(self, *args, **kwargs):
         ''' Returns an :class:`Arrow <arrow.arrow.Arrow>` object based on flexible inputs.
 
+        :param locale: (optional) a ``str`` specifying a locale for the parser. Defaults to
+            'en_us'.
+        :param tzinfo: (optional) a :ref:`timezone expression <tz-expr>` or tzinfo object.
+            Replaces the timezone unless using an input form that is explicitly UTC or specifies
+            the timezone in a positional argument. Defaults to UTC.
+
         Usage::
 
             >>> import arrow


### PR DESCRIPTION
Currently, the kwargs `locale` and `tzinfo` to `arrow.get` are undocumented. I was about to contribute code to allow timezone specification when parsing with `arrow.get`, e.g.,

```py
arrow.get('01-01 00:00', 'MM-DD HH:mm')
```

when I realized the technology has already been there:

```py
arrow.get('01-01 00:00', 'MM-DD HH:mm', tzinfo='America/New_York')
```

since #221. Therefore, I believe the documentation could be improved to expose this useful feature to more users.