### PR TITLE
Adding start_of and end_of methods

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -839,7 +839,7 @@ class Arrow(object):
             'second': 0,
             'microsecond': 0
         }
-        to_replace = {key: units_to_replace[key] for key in Arrow._ATTRS[Arrow._ATTRS.index(unit) + 1:]}
+        to_replace = dict((key, units_to_replace[key]) for key in Arrow._ATTRS[Arrow._ATTRS.index(unit) + 1:])
 
         return self.replace(**to_replace)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -802,11 +802,74 @@ class Arrow(object):
                 delta = sign * delta / float(60*60*24*365.25)
             else:
                 raise AttributeError('Error. Could not understand your level of granularity. Please select between \
-                "second", "minute", "hour", "day", "week", "month" or "year"') 
-            
+                "second", "minute", "hour", "day", "week", "month" or "year"')
+
             if(trunc(abs(delta)) != 1):
                 granularity += 's'
             return locale.describe(granularity, delta, only_distance=False)
+
+    def start_of(self, unit):
+        ''' Returns the :class:`Arrow <arrow.arrow.Arrow>` object, converted
+        to the beginning of the given target.
+
+        :param unit: A string with the type of unit to convert.
+
+        Usage::
+
+            >>> utc = arrow.utcnow()
+            >>> utc
+            <Arrow [2017-02-02T19:41:10.500007+00:00]>
+
+            >>> utc.start_of('day')
+            <Arrow [2017-02-02T00:00:00+00:00]>
+
+            >>> utc.start_of('month')
+            <Arrow [2017-02-01T00:00:00+00:00]>
+
+            >>> utc.start_of('year')
+            <Arrow [2017-01-01T00:00:00+00:00]>
+
+        '''
+
+        units_to_replace = {
+            'month': 1,
+            'day': 1,
+            'hour': 0,
+            'minute': 0,
+            'second': 0,
+            'microsecond': 0
+        }
+        to_replace = {key: units_to_replace[key] for key in Arrow._ATTRS[Arrow._ATTRS.index(unit) + 1:]}
+
+        return self.replace(**to_replace)
+
+    def end_of(self, unit):
+        ''' Returns the :class:`Arrow <arrow.arrow.Arrow>` object, converted
+        to the end of the given target.
+
+        :param unit: A string with the type of unit to convert.
+
+        Usage::
+
+            >>> utc = arrow.utcnow()
+            >>> utc
+            <Arrow [2017-02-02T19:41:10.500007+00:00]>
+
+            >>> utc.end_of('day')
+            <Arrow [2017-02-02T23:59:59.999999+00:00]>
+
+            >>> utc.end_of('month')
+            <Arrow [2017-02-28T23:59:59.999999+00:00]>
+
+            >>> utc.end_of('year')
+            <Arrow [2017-12-31T23:59:59.999999+00:00]>
+
+        '''
+
+        plural_unit = Arrow._ATTRS_PLURAL[Arrow._ATTRS.index(unit)]
+        to_replace = {plural_unit: 1}
+        return self.start_of(unit) + relativedelta(**to_replace) - relativedelta(microseconds=1)
+
     # math
 
     def __add__(self, other):

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1357,6 +1357,106 @@ class ArrowHumanizeTestsWithLocale(Chai):
         assertEqual(result, '2 года назад')
 
 
+class ArrowStartOf(Chai):
+    def test_start_of_year(self):
+        valid_date = arrow.Arrow(2016, 1, 1, 0, 0, 0)
+        arw = arrow.Arrow(2016, 5, 25, 20, 12, 32, 652040)
+
+        result = arw.start_of('year')
+
+        assertEqual(result, valid_date)
+
+    def test_start_of_month(self):
+        valid_date = arrow.Arrow(2017, 2, 1, 0, 0, 0)
+        arw = arrow.Arrow(2017, 2, 25, 20, 12, 32, 652040)
+
+        result = arw.start_of('month')
+
+        assertEqual(result, valid_date)
+
+    def test_start_of_day(self):
+        valid_date = arrow.Arrow(2017, 1, 14, 0, 0, 0)
+        arw = arrow.Arrow(2017, 1, 14, 20, 12, 32, 652040)
+
+        result = arw.start_of('day')
+
+        assertEqual(result, valid_date)
+
+    def test_start_of_hour(self):
+        valid_date = arrow.Arrow(2016, 5, 25, 20, 0, 0, 0)
+        arw = arrow.Arrow(2016, 5, 25, 20, 12, 32, 652040)
+
+        result = arw.start_of('hour')
+
+        assertEqual(result, valid_date)
+
+    def test_start_of_minute(self):
+        valid_date = arrow.Arrow(2016, 5, 25, 20, 12, 0, 0)
+        arw = arrow.Arrow(2016, 5, 25, 20, 12, 32, 652040)
+
+        result = arw.start_of('minute')
+
+        assertEqual(result, valid_date)
+
+    def test_start_of_second(self):
+        valid_date = arrow.Arrow(2017, 2, 1, 20, 12, 32, 0)
+        arw = arrow.Arrow(2017, 2, 1, 20, 12, 32, 652040)
+
+        result = arw.start_of('second')
+
+        assertEqual(result, valid_date)
+
+
+class ArrowEndOf(Chai):
+    def test_end_of_year(self):
+        valid_date = arrow.Arrow(2017, 12, 31, 23, 59, 59, 999999)
+        arw = arrow.Arrow(2017, 2, 2, 14, 31, 25, 441183)
+
+        result = arw.end_of('year')
+
+        assertEqual(result, valid_date)
+
+    def test_end_of_month(self):
+        valid_date = arrow.Arrow(2017, 2, 28, 23, 59, 59, 999999)
+        arw = arrow.Arrow(2017, 2, 2, 14, 31, 25, 441183)
+
+        result = arw.end_of('month')
+
+        assertEqual(result, valid_date)
+
+    def test_end_of_day(self):
+        valid_date = arrow.Arrow(2017, 2, 2, 23, 59, 59, 999999)
+        arw = arrow.Arrow(2017, 2, 2, 14, 31, 25, 441183)
+
+        result = arw.end_of('day')
+
+        assertEqual(result, valid_date)
+
+    def test_end_of_hour(self):
+        valid_date = arrow.Arrow(2017, 2, 2, 14, 59, 59, 999999)
+        arw = arrow.Arrow(2017, 2, 2, 14, 31, 25, 441182)
+
+        result = arw.end_of('hour')
+
+        assertEqual(result, valid_date)
+
+    def test_end_of_minute(self):
+        valid_date = arrow.Arrow(2017, 2, 2, 14, 31, 59, 999999)
+        arw = arrow.Arrow(2017, 2, 2, 14, 31, 25, 441182)
+
+        result = arw.end_of('minute')
+
+        assertEqual(result, valid_date)
+
+    def test_end_of_second(self):
+        valid_date = arrow.Arrow(2017, 2, 2, 14, 31, 25, 999999)
+        arw = arrow.Arrow(2017, 2, 2, 14, 31, 25, 441182)
+
+        result = arw.end_of('second')
+
+        assertEqual(result, valid_date)
+
+
 class ArrowUtilTests(Chai):
 
     def test_get_datetime(self):


### PR DESCRIPTION
I've made this methods to move between the start and the end of the units in a date.

I got the idea from the Javascript library momentJS, and thought that it would be good to have a similar functionality in Arrow.