### PR TITLE
Add 3.6, pypy, and pypy3, and refactor CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then make build26; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then make build27; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then make build33; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then make build34; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then make build35; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then make build36; fi
     - pip install codecov
 script: make test
 after_success: codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,27 @@
 sudo: false
 language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
+
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then make build26; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then make build27; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then make build33; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then make build34; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then make build35; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then make build36; fi
-    - pip install codecov
-script: make test
-after_success: codecov
+    - pip install tox
+script: tox
+after_success:
+  - pip install codecov
+  - codecov

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import codecs
 import os.path
 import re
+from sys import version_info
 
 try:
     from setuptools import setup
@@ -25,6 +26,15 @@ def grep(attrname):
 
 file_text = read(fpath('arrow/__init__.py'))
 
+install_requires = ['backports.functools_lru_cache',
+                    'python-dateutil',
+                    'simplejson']
+if version_info[0] == 2 and version_info[1] == 6:
+    install_requires.append('chai==0.3.1')
+else:
+    install_requires.append('chai')
+
+
 setup(
     name='arrow',
     version=grep('__version__'),
@@ -36,9 +46,7 @@ setup(
     license='Apache 2.0',
     packages=['arrow'],
     zip_safe=False,
-    install_requires=[
-        'python-dateutil'
-    ],
+    install_requires=install_requires,
     test_suite="tests",
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,7 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py{26,27,33,34,35,36,py,py3}
 skip_missing_interpreters = True
 
-[common]
-deps =
-    nose
-    nose-cov
-    simplejson
-
 [testenv]
-deps =
-    {[common]deps}
-    chai
-commands = nosetests --all-modules --with-coverage arrow tests
-
-[testenv:py26]
-deps =
-    {[common]deps}
-    chai==0.3.1
+deps = nose
+commands = nosetests --all-modules arrow tests

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,7 @@ envlist = py{26,27,33,34,35,36,py,py3}
 skip_missing_interpreters = True
 
 [testenv]
-deps = nose
-commands = nosetests --all-modules arrow tests
+deps =
+    nose
+    nose-cov
+commands = nosetests --all-modules --with-coverage --cover-package=arrow


### PR DESCRIPTION
This pull-request:

- adds python3.6, pypy, and pypy3 to the tests environment list
- moves dependency definition into setup.py while remaining sensible to python 2.6 requirements
- change travis config to use tox

If this pull-request is accepted it'll require changes to the Makefile. Project maintainer have access to this branch and can push changes before merging with master.