### PR TITLE
Fixes minor in PortugueseBrazilian locale

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -945,7 +945,7 @@ class PortugueseLocale(Locale):
 class BrazilianPortugueseLocale(PortugueseLocale):
     names = ['pt_br']
 
-    past = 'fazem {0}'
+    past = 'faz {0}'
 
 
 class TagalogLocale(Locale):


### PR DESCRIPTION
This fixes a minor grammar mistake in `BrazilianPortuguese` locale, past should not be `fazem` but `faz`.