### PR TITLE
Support microsecond precision timestamp on Python 3.3+

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -424,7 +424,10 @@ class Arrow(object):
         ''' Returns a timestamp representation of the :class:`Arrow <arrow.arrow.Arrow>` object, in
         UTC time. '''
 
-        return calendar.timegm(self._datetime.utctimetuple())
+        if hasattr(self._datetime, 'timestamp'):
+            return self._datetime.timestamp()
+        else:
+            return calendar.timegm(self._datetime.utctimetuple())
 
     @property
     def float_timestamp(self):


### PR DESCRIPTION
Previous implementation of `arrow.Arrow.timestamp()` has precision of a second, since `datetime.datetime.utctimetuple()` returns a `time.struct_time` which doesn't even have a microsecond field.

In this commit, we switch to [`datetime.datetime.timestamp()`][1], available on Python 3.3 or later, which supports microsecond precision.

By the way I'm using `hasattr` for feature test now. Not sure if you prefer try...except-styled feature test.

[1]: https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp