### PR TITLE
Fix arrow.Arrow.interval()

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -351,14 +351,11 @@ class Arrow(object):
         '''
         if interval < 1:
             raise ValueError("interval has to be a positive integer")
-
-        spanRange = cls.span_range(frame,start,end,tz)
-
-        bound = (len(spanRange) // interval) * interval
-        _range = [ (spanRange[i][0],spanRange[i+ interval - 1][1]) for i in range(0,bound, interval) ]
-        
-        if (bound < len(spanRange)):
-            _range.append((spanRange[bound][0], spanRange[-1][1]))
+        range_span = cls.span_range(frame, start, end, tz)
+        bound = (len(range_span) // interval) * interval
+        _range = [(range_span[i][0], range_span[i + interval - 1][1]) for i in range(0,bound, interval) ]        
+        if bound < len(range_span):
+            _range.append((range_span[bound][0], range_span[-1][1]))
         return _range
 
     # representations

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -355,7 +355,11 @@ class Arrow(object):
         spanRange = cls.span_range(frame,start,end,tz)
 
         bound = (len(spanRange) // interval) * interval
-        return [ (spanRange[i][0],spanRange[i+ interval - 1][1]) for i in range(0,bound, interval) ]
+        _range = [ (spanRange[i][0],spanRange[i+ interval - 1][1]) for i in range(0,bound, interval) ]
+        
+        if (bound < len(spanRange)):
+            _range.append((spanRange[bound][0], spanRange[-1][1]))
+        return _range
 
     # representations
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1001,9 +1001,20 @@ class ArrowIntervalTests(Chai):
     def test_correct(self):
         result = arrow.Arrow.interval('hour', datetime(2013, 5, 5, 12, 30), datetime(2013, 5, 5, 17, 15),2)
 
-        assertEqual(result,[(arrow.Arrow(2013, 5, 5, 12), arrow.Arrow(2013, 5, 5, 13, 59, 59, 999999)),
+        assertEqual(result,[
+            (arrow.Arrow(2013, 5, 5, 12), arrow.Arrow(2013, 5, 5, 13, 59, 59, 999999)),
             (arrow.Arrow(2013, 5, 5, 14), arrow.Arrow(2013, 5, 5, 15, 59, 59, 999999)),
-            (arrow.Arrow(2013, 5, 5, 16), arrow.Arrow(2013, 5, 5, 17, 59, 59, 999999))])
+            (arrow.Arrow(2013, 5, 5, 16), arrow.Arrow(2013, 5, 5, 17, 59, 59, 999999))
+        ])
+        
+    def test_correct2(self):
+        result = arrow.Arrow.interval('hour', datetime(2013, 5, 5, 12, 30), datetime(2013, 5, 5, 22, 15),4)
+
+        assertEqual(result,[
+            (arrow.Arrow(2013, 5, 5, 12), arrow.Arrow(2013, 5, 5, 15, 59, 59, 999999)),
+            (arrow.Arrow(2013, 5, 5, 16), arrow.Arrow(2013, 5, 5, 19, 59, 59, 999999)),
+            (arrow.Arrow(2013, 5, 5, 20), arrow.Arrow(2013, 5, 5, 22, 59, 59, 999999))
+        ])
 
 class ArrowSpanTests(Chai):
 


### PR DESCRIPTION
arrow.Arrow.interval() produces unexpected results if the interval doesn't evenly divide the range. It leaves off the last chunk of time.

```shell
$> start = datetime(2013, 5, 5, 12, 30)
$> end = datetime(2013, 5, 5, 17, 15)
$> for r in arrow.Arrow.interval('hour', start, end, 4): print (r)
(<Arrow [2013-05-05T12:00:00+00:00]>, <Arrow [2013-05-05T15:59:59.999999+00:00]>)
```

Expected result:
```shell
$> for r in arrow.Arrow.interval('hour', start, end, 4): print (r)
(<Arrow [2013-05-05T12:00:00+00:00]>, <Arrow [2013-05-05T15:59:59.999999+00:00]>)
(<Arrow [2013-05-05T16:00:00+00:00]>, <Arrow [2013-05-05T17:59:59.999999+00:00]>)
```