### PR TITLE
Escape regex special characters.

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -133,9 +133,9 @@ class DateTimeParser(object):
         escaped_fmt = re.sub('S+', 'S', escaped_fmt)
         escaped_data = re.findall(self._ESCAPE_RE, fmt)
 
-        fmt_pattern = escaped_fmt
+        fmt_pattern = re.escape(escaped_fmt)
 
-        for m in self._FORMAT_RE.finditer(escaped_fmt):
+        for m in self._FORMAT_RE.finditer(fmt_pattern):
             token = m.group(0)
             try:
                 input_re = self._input_re_map[token]
@@ -151,7 +151,7 @@ class DateTimeParser(object):
             offset += len(input_pattern) - (m.end() - m.start())
 
         final_fmt_pattern = ""
-        a = fmt_pattern.split("#")
+        a = fmt_pattern.split("\#")
         b = escaped_data
 
         # Due to the way Python splits, 'a' will always be longer

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -836,3 +836,9 @@ class DateTimeParserSearchDateTests(Chai):
         assertEqual(
             self.parser.parse("I'm entirely escaped, weee!", format),
             datetime(1, 1, 1))
+
+    def test_regex_escapes(self):
+
+        assertEqual(
+            self.parser.parse("\\$^.*?+{}|2017(01)", "\\$^.*?+{}|YYYY(MM)"),
+            datetime(2017, 1, 1))


### PR DESCRIPTION
Escape regex special characters in format string.

I ran into an issue when trying to parse a string in the format "YYYY(MM)" and it no longer would match the generated regex.

While it is currently possible to match under the current behavior by pre-escaping yourself, e.g., "YYYY\(MM\)", this seems non-intuitive.

This is applied after the [...] escaping to maintain the current behavior.