### PR TITLE
raise ParserError if year, month, or date is not found in string

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -180,7 +180,7 @@ class DateTimeParser(object):
             else:
                 value = match.group(token)
             self._parse_token(token, value, parts)
-        return self._build_datetime(parts)
+        return self._build_datetime(parts, fmt_pattern_re.pattern, string)
 
     def _parse_token(self, token, value, parts):
 
@@ -247,7 +247,7 @@ class DateTimeParser(object):
                 parts['am_pm'] = 'pm'
 
     @staticmethod
-    def _build_datetime(parts):
+    def _build_datetime(parts, pattern, string):
 
         timestamp = parts.get('timestamp')
 
@@ -262,6 +262,9 @@ class DateTimeParser(object):
             hour += 12
         elif am_pm == 'am' and hour == 12:
             hour = 0
+
+        if not parts.get('year') or not parts.get('month') or not parts.get('day'):
+            raise ParserError('Could not match input to any of {0} on \'{1}\''.format(pattern, string))
 
         return datetime(year=parts.get('year', 1), month=parts.get('month', 1),
             day=parts.get('day', 1), hour=hour, minute=parts.get('minute', 0),

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -236,6 +236,10 @@ class DateTimeParserParseTests(Chai):
         assertEqual(self.parser.parse('2013-01-01 12:30:45.987654', 'YYYY-MM-DD HH:mm:ss.SSSSSS'), expected)
         assertEqual(self.parser.parse_iso('2013-01-01 12:30:45.987654'), expected)
 
+    def test_parse_unsupported_iso(self):
+        with assertRaises(ParserError):
+            self.parser.parse_iso('03.04.2017')
+
     def test_parse_subsecond_rounding(self):
         expected = datetime(2013, 1, 1, 12, 30, 45, 987654)
         format = 'YYYY-MM-DD HH:mm:ss.S'


### PR DESCRIPTION
this attempts to resolve https://github.com/crsmithdev/arrow/issues/456

using `arrow.get('31.12.2017')` as an example, the input string matches the format YYYY generated by parser.parse_isoformat. As a result, only year is parsed from the input string which leads to month and date defaulting to 1 in  _build_datetime.

This attempts to resolve the attached issue by raising parser error if year, date or month is missing from the  parts parameter provided to _build_datetime 