### PR TITLE
Tagalog locale additions

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -962,7 +962,8 @@ class TagalogLocale(Locale):
 
     timeframes = {
         'now': 'ngayon lang',
-        'seconds': 'segundo',
+        'second': 'isang segundo',
+        'seconds': '{0} segundo',
         'minute': 'isang minuto',
         'minutes': '{0} minuto',
         'hour': 'isang oras',

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -186,7 +186,7 @@ class Locale(object):
 
 class EnglishLocale(Locale):
 
-    names = ['en', 'en_us', 'en_gb', 'en_au', 'en_be', 'en_jp', 'en_za', 'en_ca']
+    names = ['en', 'en_us', 'en_gb', 'en_au', 'en_be', 'en_jp', 'en_za', 'en_ca', 'en_ph']
 
     past = '{0} ago'
     future = 'in {0}'
@@ -955,7 +955,7 @@ class BrazilianPortugueseLocale(PortugueseLocale):
 
 class TagalogLocale(Locale):
 
-    names = ['tl']
+    names = ['tl', 'tl_ph']
 
     past = 'nakaraang {0}'
     future = '{0} mula ngayon'

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -962,8 +962,7 @@ class TagalogLocale(Locale):
 
     timeframes = {
         'now': 'ngayon lang',
-        'second': 'isang segundo',
-        'seconds': '{0} segundo',
+        'seconds': 'segundo',
         'minute': 'isang minuto',
         'minutes': '{0} minuto',
         'hour': 'isang oras',

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -983,6 +983,8 @@ class TagalogLocale(Locale):
     day_names = ['', 'Lunes', 'Martes', 'Miyerkules', 'Huwebes', 'Biyernes', 'Sabado', 'Linggo']
     day_abbreviations = ['', 'Lun', 'Mar', 'Miy', 'Huw', 'Biy', 'Sab', 'Lin']
 
+    def _ordinal_number(self, n):
+        return 'ika-{0}'.format(n)
 
 class VietnameseLocale(Locale):
 

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -644,3 +644,22 @@ class IndonesianLocaleTests(Chai):
 
     def test_format_relative_future(self):
         self.assertEqual(self.locale._format_relative('1 jam', 'hour', -1), '1 jam yang lalu')
+
+
+class TagalogLocaleTests(Chai):
+
+    def setUp(self):
+        super(TagalogLocaleTests, self).setUp()
+
+        self.locale = locales.TagalogLocale()
+
+    def test_ordinal_number(self):
+        assertEqual(self.locale.ordinal_number(0), 'ika-0')
+        assertEqual(self.locale.ordinal_number(1), 'ika-1')
+        assertEqual(self.locale.ordinal_number(2), 'ika-2')
+        assertEqual(self.locale.ordinal_number(3), 'ika-3')
+        assertEqual(self.locale.ordinal_number(10), 'ika-10')
+        assertEqual(self.locale.ordinal_number(23), 'ika-23')
+        assertEqual(self.locale.ordinal_number(100), 'ika-100')
+        assertEqual(self.locale.ordinal_number(103), 'ika-103')
+        assertEqual(self.locale.ordinal_number(114), 'ika-114')

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -655,13 +655,12 @@ class TagalogLocaleTests(Chai):
 
     def test_format_timeframe(self):
 
-        assertEqual(self.locale._format_timeframe('second', 1), 'isang segundo')
         assertEqual(self.locale._format_timeframe('minute', 1), 'isang minuto')
         assertEqual(self.locale._format_timeframe('hour', 1), 'isang oras')
         assertEqual(self.locale._format_timeframe('month', 1), 'isang buwan')
         assertEqual(self.locale._format_timeframe('year', 1), 'isang taon')
 
-        assertEqual(self.locale._format_timeframe('seconds', 2), '2 segundo')
+        assertEqual(self.locale._format_timeframe('seconds', 2), 'segundo')
         assertEqual(self.locale._format_timeframe('minutes', 3), '3 minuto')
         assertEqual(self.locale._format_timeframe('hours', 4), '4 oras')
         assertEqual(self.locale._format_timeframe('months', 5), '5 buwan')

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -653,6 +653,29 @@ class TagalogLocaleTests(Chai):
 
         self.locale = locales.TagalogLocale()
 
+    def test_format_timeframe(self):
+
+        assertEqual(self.locale._format_timeframe('second', 1), 'isang segundo')
+        assertEqual(self.locale._format_timeframe('minute', 1), 'isang minuto')
+        assertEqual(self.locale._format_timeframe('hour', 1), 'isang oras')
+        assertEqual(self.locale._format_timeframe('month', 1), 'isang buwan')
+        assertEqual(self.locale._format_timeframe('year', 1), 'isang taon')
+
+        assertEqual(self.locale._format_timeframe('seconds', 2), '2 segundo')
+        assertEqual(self.locale._format_timeframe('minutes', 3), '3 minuto')
+        assertEqual(self.locale._format_timeframe('hours', 4), '4 oras')
+        assertEqual(self.locale._format_timeframe('months', 5), '5 buwan')
+        assertEqual(self.locale._format_timeframe('years', 6), '6 taon')
+
+    def test_format_relative_now(self):
+        self.assertEqual(self.locale._format_relative('ngayon lang', 'now', 0), 'ngayon lang')
+
+    def test_format_relative_past(self):
+        self.assertEqual(self.locale._format_relative('2 oras', 'hour', 2), '2 oras mula ngayon')
+
+    def test_format_relative_future(self):
+        self.assertEqual(self.locale._format_relative('3 oras', 'hour', -3), 'nakaraang 3 oras')
+
     def test_ordinal_number(self):
         assertEqual(self.locale.ordinal_number(0), 'ika-0')
         assertEqual(self.locale.ordinal_number(1), 'ika-1')


### PR DESCRIPTION
Tagalog ordinal number formatting taken from _Manwal sa Masinop na Pagsulat_ p.78. I closed a [previous PR](https://github.com/crsmithdev/arrow/pull/469) I made related to this as I overlooked the already existing TagalogLocale.