### PR TITLE
include ZZZ in format example as a hint

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -78,6 +78,11 @@ class ArrowFactory(object):
             >>> arrow.get('2013-09-29T01:26:43.830580')
             <Arrow [2013-09-29T01:26:43.830580+00:00]>
 
+        **One** ISO-8601-formatted ``str`` with tz name, to parse it::
+
+            >>> arrow.get('2013-11-29T01:26:43.830580 America/Chicago')
+            <Arrow [2013-11-29T01:26:43.830580-06:00]>
+
         **One** ``tzinfo``, to get the current time **converted** to that timezone::
 
             >>> arrow.get(tz.tzlocal())

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -112,8 +112,8 @@ class ArrowFactory(object):
 
         **Two** arguments, both ``str``, to parse the first according to the format of the second::
 
-            >>> arrow.get('2013-05-05 12:30:45', 'YYYY-MM-DD HH:mm:ss')
-            <Arrow [2013-05-05T12:30:45+00:00]>
+            >>> arrow.get('2013-05-05 12:30:45 America/Chicago', 'YYYY-MM-DD HH:mm:ss ZZZ')
+            <Arrow [2013-05-05T12:30:45-05:00]>
 
         **Two** arguments, first a ``str`` to parse and second a ``list`` of formats to try::
 

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -83,13 +83,21 @@ class DateTimeParser(object):
     def parse_iso(self, string):
 
         has_time = 'T' in string or ' ' in string.strip()
-        space_divider = ' ' in string.strip()
+        space_divider = 'T' not in string and ' ' in string.strip()
+        has_tzname = ('T' in string and string.count(' ') == 1 or
+                      string.count(' ') == 2)
 
         if has_time:
             if space_divider:
-                date_string, time_string = string.split(' ', 1)
+                if has_tzname:
+                    date_string, time_string, _ = string.split(' ', 2)
+                else:
+                    date_string, time_string = string.split(' ', 1)
             else:
                 date_string, time_string = string.split('T', 1)
+                if has_tzname:
+                    time_string, _ = time_string.split(' ', 1)
+
             time_parts = re.split('[+-]', time_string, 1)
             has_tz = len(time_parts) > 1
             has_seconds = time_parts[0].count(':') > 1
@@ -112,6 +120,9 @@ class DateTimeParser(object):
 
         if has_time and has_tz:
             formats = [f + 'Z' for f in formats]
+
+        if has_tzname:
+            formats = [f + ' ZZZ' for f in formats]
 
         if space_divider:
             formats = [item.replace('T', ' ', 1) for item in formats]

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -96,6 +96,14 @@ class GetTests(Chai):
 
         assertDtEqual(self.factory.get(dt.isoformat()), dt.replace(tzinfo=tz.tzutc()))
 
+    def test_one_arg_iso_str_with_tzname(self):
+
+        time_string = "2017-11-07T05:15:00.123 America/Chicago"
+
+        assertDtEqual(self.factory.get(time_string),
+                      self.factory.get(time_string, 
+                                       "YYYY-MM-DDTHH:mm:ss.S ZZZ"))
+        
     def test_one_arg_other(self):
 
         with assertRaises(TypeError):


### PR DESCRIPTION
Extends the format example to use ZZZ so it's more readily apparent how to specify timezone names.