### PR TITLE
Add appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+build: false
+environment:
+  matrix:
+    - PYTHON: "C:/Python27"
+    - PYTHON: "C:/Python33"
+    - PYTHON: "C:/Python34"
+    - PYTHON: "C:/Python35"
+    - PYTHON: "C:/Python36"
+
+    # Run on 64-bit version of latest versions
+    - PYTHON: "C:/Python27-x64"
+    - PYTHON: "C:/Python36-x64"
+
+install:
+  # Set up the virtualenv for this Python version
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "virtualenv local"
+  - "local/Scripts/activate"
+
+  # Show in the logs that we're using the right version
+  - "python --version"
+
+  # Install test requirements
+  - "pip install -r requirements.txt"
+  - "pip install codecov"
+
+test_script:
+  - "nosetests"
+after_test:
+  - "codecov"


### PR DESCRIPTION
This adds a configuration script for [Appveyor](https://www.appveyor.com/), which runs its CI on Windows machines. This will allow the CI to run Windows-specific tests for issues like #374.

One of the maintainers will have to set up the builds on Appveyor, then add in the webhooks in the settings. I did this for my fork to debug the script, you can see the results in pganssle/arrow#1. I probably would recommend turning off branch builds other than master, since Appveyor can be quite slow and if people are pushing to branches on the crsmithdev/arrow repo, it will build the exact same thing twice, for every push.