### PR TITLE
Relax dependency backports.functools-lru-cache to be >= 1.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ nose-cov==1.6
 chai==1.1.1
 sphinx==1.3.5
 simplejson==3.6.5
-backports.functools_lru_cache==1.2.1
+backports.functools_lru_cache>=1.2.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ file_text = read(fpath('arrow/__init__.py'))
 
 install_requires = ['python-dateutil']
 if sys.version_info[0] < 3:
-    install_requires.append('backports.functools_lru_cache==1.2.1')
+    install_requires.append('backports.functools_lru_cache>=1.2.1')
 
 setup(
     name='arrow',


### PR DESCRIPTION
`backports.functools-lru-cache` is up to version 1.4.  Because of how setuptools ends up calculating transitive dependencies, if you depend on something that depends on `backports.functools-lru-cache` (no version specified), and depend on something that depends on `arrow` that depends on `backports.functools-lru-cache==1.2.1`, you can end up with setuptools pulling in `backports.functools-lru-cache` at 1.4, and skipping/ignoring the `==1.2.1` requirement.

This then breaks execution, as package requirements aren't satisfied.

I've run the complete test suite on both linux and macos using 1.4 (latest), with no issue.  And, of course, the travis builds for this pr should pull in 1.4 as well, because of the relaxed requirements.

fixes #497 