### PR TITLE
Makes the only_distance paramter value equivalent to value given to f…

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -806,7 +806,7 @@ class Arrow(object):
             
             if(trunc(abs(delta)) != 1):
                 granularity += 's'
-            return locale.describe(granularity, delta, only_distance=False)
+            return locale.describe(granularity, delta, only_distance=only_distance)
     # math
 
     def __add__(self, other):

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1166,6 +1166,10 @@ class ArrowHumanizeTests(Chai):
         later108 = self.now.shift(seconds=10 ** 8)
         assertEqual(self.now.humanize(later108, granularity = 'year'), '3 years ago')
         assertEqual(later108.humanize(self.now, granularity = 'year'), 'in 3 years')
+
+        later108onlydistance = self.now.shift(seconds=10 ** 8)
+        assertEqual(self.now.humanize(later108onlydistance , only_distance=True, granularity = 'year'), '3 years')
+        assertEqual(later108onlydistance .humanize(self.now, only_distance=True, granularity = 'year'), '3 years')
         with assertRaises(AttributeError):
             self.now.humanize(later108, granularity = 'years')
     


### PR DESCRIPTION
The humanize function disregarded the value of only_distance when granularity value was also given. This request changed the default value("False") to match the given input value.

Also added  two testcases for the same.

This fixes #500 .