### PR TITLE
Allow wheels to determine the required dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 nosetests.xml
 
 local/
+build/
 dist/
 docs/_build/
 .idea

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,6 @@ def grep(attrname):
 
 file_text = read(fpath('arrow/__init__.py'))
 
-install_requires = ['python-dateutil']
-if sys.version_info[0] < 3:
-    install_requires.append('backports.functools_lru_cache==1.2.1')
-
 setup(
     name='arrow',
     version=grep('__version__'),
@@ -41,7 +37,12 @@ setup(
     license='Apache 2.0',
     packages=['arrow'],
     zip_safe=False,
-    install_requires=install_requires,
+    install_requires=[
+        'python-dateutil',
+    ],
+    extras_require={
+        ":python_version=='2.7'": ['backports.functools_lru_cache>=1.2.1'],
+    },
     test_suite="tests",
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This allows universal wheels to be generated and reliably installed.

## Background

Version 0.11 (of **arrow**) introduced caching, but based on a feature that was added to the Python standard library post-2.7. This meant that *arrow* became un-usable with Python 2.7.

Version 0.12 was released to fix the above problem. It did this by adding the [following code to setup.py](https://github.com/crsmithdev/arrow/blob/66ac19380931e9bc0497aa5ecd0f34632f4e06cd/setup.py#L29-L31):

```py
install_requires = ['python-dateutil']
if sys.version_info[0] < 3:
    install_requires.append('backports.functools_lru_cache==1.2.1')
```

This code declares the required dependency, but requires code to run on install to do so. Wheels *do not run code at install time*, rather *code is run on wheel generation*. This meant that generated wheels would either always require this backports package (if the wheel was generated by a system running Python 2.7) or never require it (if the wheel was generated by a system running Python 3). Even though **arrow** does not provide wheels on PyPI, this can still cause issues. This is because `pip`, on end user machines, will generate and cache a wheel when downloading source distributions (like **arrow** provides), and this pip cache, and thus the generated wheel, is shared by all version of Python installed on the end user's machine, and used for later installs.

## Solution

This PR declares the required dependency in a conditional way that wheel can read it on install.

## Further Reading

- [Conditional Python Dependencies](https://hynek.me/articles/conditional-python-dependencies/)
- Wheel Documentation -- [Defining conditional dependencies](https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies)