### PR TITLE
update functools-lru-cache to avoid import problems fixes #497

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ nose-cov==1.6
 chai==1.1.1
 sphinx==1.3.5
 simplejson==3.6.5
-backports.functools_lru_cache==1.2.1
+backports.functools_lru_cache==1.4


### PR DESCRIPTION
otherwise import fails after upgrading to 0.12