### PR TITLE
Fix arrow.get() to work with str+tzinfo

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -172,7 +172,7 @@ class ArrowFactory(object):
             # (str) -> parse.
             elif isstr(arg):
                 dt = parser.DateTimeParser(locale).parse_iso(arg)
-                return self.type.fromdatetime(dt)
+                return self.type.fromdatetime(dt, tz)
 
             # (struct_time) -> from struct_time
             elif isinstance(arg, struct_time):

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -149,6 +149,12 @@ class GetTests(Chai):
 
         assertEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.tzutc()))
 
+    def test_two_args_str_tzinfo(self):
+
+        result = self.factory.get('2013-01-01', tzinfo=tz.gettz('US/Pacific'))
+
+        assertDtEqual(result._datetime, datetime(2013, 1, 1, tzinfo=tz.gettz('US/Pacific')))
+
     def test_two_args_twitter_format(self):
 
         # format returned by twitter API for created_at:


### PR DESCRIPTION
Allow arrow.get() to be called with str+tzinfo parameter combo.

Before this fix:
```
In: arrow.get('2018-01-29 14:46', tzinfo=tz.timezone('US/Central'))
Out: <Arrow [2018-01-29T14:46:00+00:00]>
```
After:
```
In: arrow.get('2018-01-29 14:46', tzinfo=tz.gettz('US/Pacific'))
Out: <Arrow [2018-01-29T14:46:00-08:00]>
```

Fixes #515, #462, and #493.