### PR TITLE
Python2.7 functools_lru_cache above 1.3 not working

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ nose-cov==1.6
 chai==1.1.1
 sphinx==1.3.5
 simplejson==3.6.5
-backports.functools_lru_cache==1.2.1
+backports.functools_lru_cache>=1.2.1,<1.4

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'python-dateutil',
     ],
     extras_require={
-        ":python_version=='2.7'": ['backports.functools_lru_cache>=1.2.1,<1.4'],
+        ":python_version<='2.7'": ['backports.functools_lru_cache>=1.2.1,<1.4'],
     },
     test_suite="tests",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'python-dateutil',
     ],
     extras_require={
-        ":python_version=='2.7'": ['backports.functools_lru_cache>=1.2.1'],
+        ":python_version=='2.7'": ['backports.functools_lru_cache>=1.2.1,<1.4'],
     },
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
Fixes #495 

When using Python 2.7 a not working `backports.functools-lru-cache` is getting installed. `backports.functools-lru-cache` above 1.3 gives an import error. This PR pins the required version between 1.2.1 and <1.4 and gets it working for now. 

This issue wasn't failing tests because the in the [`requirements.txt`](https://github.com/crsmithdev/arrow/blob/master/requirements.txt) the version is pinned to 1.2.1 but that wasn't the case in [`setup.py`](https://github.com/crsmithdev/arrow/blob/master/setup.py).
Corrected this with the second commit.

This issue seems to have something to do with [this issue](https://github.com/jaraco/backports.functools_lru_cache/issues/10) over at `jaraco/backports.functools-lru-cache`. 
Reopened the issue and waiting for a response but this hotfixes the issue for now 👍 