### PR TITLE
No error raised on invalid dates

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -165,6 +165,19 @@ class DateTimeParser(object):
 
         return tokens, re.compile(final_fmt_pattern, flags=re.IGNORECASE)
 
+    def check_incorrect_year_placement(self, string, fmt):
+        """
+        Determines wheather a year (YYYY) is incorrectly formatted.
+        """
+        if fmt == 'YYYY-MM-DD' or fmt == 'YYYY/MM/DD' or fmt == 'YYYY.MM.DD':
+            # Ensuring that the 3rd and 4th number of a date is a number
+            # instead of a '-', '/', or '.'
+            if not string[2].isdigit() or not string[3].isdigit():
+                return True
+            return False
+        else:
+            return False
+
     def parse(self, string, fmt):
 
         if isinstance(fmt, list):
@@ -280,6 +293,10 @@ class DateTimeParser(object):
                 _datetime = self.parse(string, fmt)
                 break
             except ParserError:
+                if self.check_incorrect_year_placement(string, fmt):
+                    # For an invalid string, set datetime to 'None' to fire an exception
+                    _datetime = None
+                    break
                 pass
 
         if _datetime is None:

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -297,7 +297,6 @@ class DateTimeParser(object):
                     # For an invalid string, set datetime to 'None' to fire an exception
                     _datetime = None
                     break
-                pass
 
         if _datetime is None:
             raise ParserError('Could not match input to any of {0} on \'{1}\''.format(formats, string))

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -294,8 +294,6 @@ class DateTimeParser(object):
                 break
             except ParserError:
                 if self.check_incorrect_year_placement(string, fmt):
-                    # For an invalid string, set datetime to 'None' to fire an exception
-                    _datetime = None
                     break
 
         if _datetime is None:

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -375,6 +375,25 @@ class DateTimeParserISOTests(Chai):
                 self.parser.parse_iso(separator.join(('2013', '02', '03'))),
                 datetime(2013, 2, 3)
             )
+    
+    def test_incorrect_year_placement(self):
+        """
+        Tests when year is in the wrong slot.
+        """
+
+        with assertRaises(ParserError):
+            self.parser.parse_iso('02-2018-03')
+	
+	    with assertRaises(ParserError):
+	    	self.parser.parse_iso('02-03-2018')
+        
+        with assertRaises(ParserError):
+            self.parser.parse_iso('02/2018/03')
+
+        with assertRaises(ParserError):
+            self.parser.parse_iso('02/03/2018')
+
+
 
     def test_YYYY_MM_DDTHH_mmZ(self):
 

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -393,6 +393,13 @@ class DateTimeParserISOTests(Chai):
         with assertRaises(ParserError):
             self.parser.parse_iso('02/03/2018')
 
+        with assertRaises(ParserError):
+            self.parser.parse_iso('02.2018.03')
+
+        with assertRaises(ParserError):
+            self.parser.parse_iso('02.03.2018')
+
+
 
 
     def test_YYYY_MM_DDTHH_mmZ(self):

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -383,10 +383,10 @@ class DateTimeParserISOTests(Chai):
 
         with assertRaises(ParserError):
             self.parser.parse_iso('02-2018-03')
-	
-	    with assertRaises(ParserError):
-	    	self.parser.parse_iso('02-03-2018')
-        
+
+        with assertRaises(ParserError):
+            self.parser.parse_iso('02-03-2018')
+
         with assertRaises(ParserError):
             self.parser.parse_iso('02/2018/03')
 


### PR DESCRIPTION
#519 

Implemented a fix that throws a parser error when a year is incorrectly placed in a date.  This fix applies in situations where a string is entered for a date.

### Before change behavior:
```
>>> arrow.get('02-03-2018')                                            
<Arrow [2018-01-01T00:00:00+00:00]>
```
### After change behavior:
```
>>> arrow.get('02-03-2018')                                            
Traceback (most recent call last):                                       
File "<stdin>", line 1, in <module>                                    
File "/mnt/c/Users/Andrew/Documents/College_Work/eecs481/hw6/arrow/arrow/api.py", line 22, in get                                               
return _factory.get(*args, **kwargs)                                 
File "/mnt/c/Users/Andrew/Documents/College_Work/eecs481/hw6/arrow/arrow/factory.py", line 174, in get                                          
dt = parser.DateTimeParser(locale).parse_iso(arg)                    
File "/mnt/c/Users/Andrew/Documents/College_Work/eecs481/hw6/arrow/arrow/parser.py", line 119, in parse_iso                                     
return self._parse_multiformat(string, formats)                      
File "/mnt/c/Users/Andrew/Documents/College_Work/eecs481/hw6/arrow/arrow/parser.py", line 303, in _parse_multiformat                            
raise ParserError('Could not match input to any of {0} on \'{1}\''.format(formats, string))                                               
arrow.parser.ParserError: Could not match input to any of [u'YYYY-MM-DD', u'YYYY/MM/DD', u'YYYY.MM.DD', u'YYYY-MM', u'YYYY/MM', u'YYYY.MM', u'YYYY', u'YYYY', u'YYYY'] on '02-03-2018'
```