### PR TITLE
added latitude/longitude support for the creation and modification of…

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -15,7 +15,6 @@ import calendar
 import sys
 import warnings
 
-import pytz
 from tzwhere import tzwhere
 
 from arrow import util, locales, parser, formatter

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -15,6 +15,8 @@ import calendar
 import sys
 import warnings
 
+import pytz
+from tzwhere import tzwhere
 
 from arrow import util, locales, parser, formatter
 
@@ -80,6 +82,25 @@ class Arrow(object):
         '''
 
         tzinfo = tzinfo if tzinfo is not None else dateutil_tz.tzlocal()
+        dt = datetime.now(tzinfo)
+
+        return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
+            dt.microsecond, dt.tzinfo)
+
+    @classmethod
+    def now_geo(cls, latitude, longitude):
+        '''Constructs an :class:`Arrow <arrow.arrow.Arrow>` object, representing "now" in the given
+        latitude/longitude pairing.
+
+        :param latitude: float representing latitude
+        :param longitude: float representing longitude
+
+        '''
+
+        tz_where = tzwhere.tzwhere()
+        tz = tz_where.tzNameAt(latitude, longitude)
+
+        tzinfo = parser.TzinfoParser.parse(tz)
         dt = datetime.now(tzinfo)
 
         return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
@@ -588,6 +609,33 @@ class Arrow(object):
 
         if not isinstance(tz, tzinfo):
             tz = parser.TzinfoParser.parse(tz)
+
+        dt = self._datetime.astimezone(tz)
+
+        return self.__class__(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
+            dt.microsecond, dt.tzinfo)
+
+    def to_geo(self, latitude, longitude):
+        ''' Returns a new :class:`Arrow <arrow.arrow.Arrow>` object, converted
+        to the timezone represented by a latitude/longitude pairing.
+
+        :param latitude: float representing latitude coordinate
+        :param longitude: float representing longitude coordinate
+
+        Usage::
+
+            >>> utc = arrow.utcnow()
+            >>> utc
+            <Arrow [2013-05-09T03:49:12.311072+00:00]>
+
+            >>> utc.to_geo('34.42, -119.69')
+            <Arrow [2013-05-08T20:49:12.311072-07:00]>
+
+        '''
+        tz_where = tzwhere.tzwhere()
+        tz = tz_where.tzNameAt(latitude, longitude)
+
+        tz = parser.TzinfoParser.parse(tz)
 
         dt = self._datetime.astimezone(tz)
 

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -17,7 +17,6 @@ from dateutil import tz as dateutil_tz
 from time import struct_time
 import calendar
 
-import pytz
 from tzwhere import tzwhere
 
 

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -17,6 +17,9 @@ from dateutil import tz as dateutil_tz
 from time import struct_time
 import calendar
 
+import pytz
+from tzwhere import tzwhere
+
 
 class ArrowFactory(object):
     ''' A factory for generating :class:`Arrow <arrow.arrow.Arrow>` objects.
@@ -254,5 +257,17 @@ class ArrowFactory(object):
             tz = dateutil_tz.tzlocal()
         elif not isinstance(tz, tzinfo):
             tz = parser.TzinfoParser.parse(tz)
+
+        return self.type.now(tz)
+
+    def now_geo(self, latitude, longitude):
+        '''Returns an :class:`Arrow <arrow.arrow.Arrow>` object, representing "now" in the given
+        latitude/longitude.
+
+        '''
+
+        tz_where = tzwhere.tzwhere()
+        tz = tz_where.tzNameAt(latitude, longitude)
+        tz = parser.TzinfoParser.parse(tz)
 
         return self.type.now(tz)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ chai==1.1.1
 sphinx==1.3.5
 simplejson==3.6.5
 backports.functools_lru_cache==1.2.1
+pytz
+tzwhere

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ chai==1.1.1
 sphinx==1.3.5
 simplejson==3.6.5
 backports.functools_lru_cache==1.2.1
-pytz
 tzwhere

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -14,6 +14,9 @@ import pickle
 import time
 import sys
 
+import pytz
+from tzwhere import tzwhere
+
 from arrow import arrow, util
 
 
@@ -39,6 +42,13 @@ class ArrowFactoryTests(Chai):
         result = arrow.Arrow.now()
 
         assertDtEqual(result._datetime, datetime.now().replace(tzinfo=tz.tzlocal()))
+
+    def test_now_geo(self):
+
+        result = arrow.Arrow.now_geo(34.42, -119.69)
+        result_cmp = arrow.Arrow.now().to('US/Pacific')
+
+        assertDtEqual(result._datetime, result_cmp._datetime)
 
     def test_utcnow(self):
 
@@ -468,6 +478,15 @@ class ArrowConversionTests(Chai):
         assertEqual(arrow_from.to('UTC').datetime, expected)
         assertEqual(arrow_from.to(tz.tzutc()).datetime, expected)
 
+    def test_to_geo(self):
+
+        arw = arrow.Arrow.utcnow()
+        arw_cmp = arw
+
+        local = arw.to('US/Pacific')
+        local_cmp = arw_cmp.to_geo(34.42, -119.69)
+
+        assertEqual(arw.datetime, arw_cmp.datetime)
 
 class ArrowPicklingTests(Chai):
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -14,7 +14,6 @@ import pickle
 import time
 import sys
 
-import pytz
 from tzwhere import tzwhere
 
 from arrow import arrow, util

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -224,3 +224,7 @@ class NowTests(Chai):
     def test_tz_str(self):
 
         assertDtEqual(self.factory.now('EST'), datetime.now(tz.gettz('EST')))
+
+    def test_now_geo(self):
+
+        assertDtEqual(self.factory.now('US/Pacific'), self.factory.now_geo(34.42, -119.69))


### PR DESCRIPTION
added to_geo and now_geo functions to the Arrow model which allows latitude/longitude specification as a way of describing timezone when creating a new arrow object. Also added a now_geo function to the factory which has same functionality. Created tests for each of the new methods in the respective test files. 