### PR TITLE
Add Support for KWARGS construction (Response to issue#415)

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -7,7 +7,7 @@ replacement.
 
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, tzinfo, date
 from dateutil import tz as dateutil_tz
 from dateutil.relativedelta import relativedelta
 from math import trunc
@@ -191,6 +191,19 @@ class Arrow(object):
         return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second,
                    dt.microsecond, tzinfo)
 
+
+    @classmethod
+    def fromkwargs(cls, year=2013, month=5, day=5):
+        ''' Constructs an :class:`Arrow <arrow.arrow.Arrow>` object from a year string, month string,
+            and day string similar to the datetime constructor
+
+                :param year: the year.
+                :param month: the month.
+                :param day: the day.
+                '''
+
+        dt = date(year=year, month=month, day=day)
+        return cls(dt.year, dt.month, dt.day)
 
     # factories: ranges and spans
 

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -125,6 +125,9 @@ class ArrowFactory(object):
             >>> arrow.get(2013, 5, 5, 12, 30, 45)
             <Arrow [2013-05-05T12:30:45+00:00]>
 
+            >>> arrow.get(year=2013, month=5, day=5)
+            <Arrow [2013-05-05T12:00:00+00:00]>
+
         **One** time.struct time::
 
             >>> arrow.get(gmtime(0))
@@ -138,13 +141,31 @@ class ArrowFactory(object):
 
         # () -> now, @ utc.
         if arg_count == 0:
+            '''
+                Set up structure for kwargs construction
+                - Default date is 2013, 5, 5
+                - User can construct by passing any of or all of year month and day
+            '''
+            flag = False
+            year, month, day = 2013, 5, 5
+            if 'year' in kwargs:
+                flag = True
+                year = kwargs['year']
+            if 'month' in kwargs:
+                flag = True
+                month = kwargs['month']
+            if 'day' in kwargs:
+                flag = True
+                day = kwargs['day']
+            if flag:
+                return self.type.fromkwargs(year=year, month=month,day=day)
+
             if isinstance(tz, tzinfo):
                 return self.type.now(tz)
             return self.type.utcnow()
 
         if arg_count == 1:
             arg = args[0]
-
             # (None) -> now, @ utc.
             if arg is None:
                 return self.type.utcnow()
@@ -182,7 +203,6 @@ class ArrowFactory(object):
                 raise TypeError('Can\'t parse single argument type of \'{0}\''.format(type(arg)))
 
         elif arg_count == 2:
-
             arg_1, arg_2 = args[0], args[1]
 
             if isinstance(arg_1, datetime):

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -193,6 +193,36 @@ class GetTests(Chai):
 
         assertEqual(self.factory.get(2013, 1, 1), datetime(2013, 1, 1, tzinfo=tz.tzutc()))
 
+    def test_three_args_kw_style1(self):
+
+        result = self.factory.get(year=2015, month=6, day=7)
+        assertEqual(result, self.factory.get(datetime(2015, 6, 7)))
+
+    def test_three_args_kw_style2(self):
+
+        result = self.factory.get(year=2016, month=5, day=4)
+        assertEqual(result, self.factory.get(datetime(2016, 5, 4)))
+
+    def test_three_args_kw_style3(self):
+
+        result = self.factory.get(year=2016)
+        assertEqual(result, self.factory.get(datetime(2016, 5, 5)))
+
+    def test_three_args_kw_style4(self):
+
+        result = self.factory.get(month=8)
+        assertEqual(result, self.factory.get(datetime(2013, 8, 5)))
+
+    def test_three_args_kw_style5(self):
+
+        result = self.factory.get(day=22)
+        assertEqual(result, self.factory.get(datetime(2013, 5, 22)))
+
+    def test_three_args_kw_style6(self):
+
+        result = self.factory.get(year=2016, month=7)
+        assertEqual(result, self.factory.get(datetime(2016, 7, 5)))
+
 
 class UtcNowTests(Chai):
 


### PR DESCRIPTION
This pull request is a response to issue#415 (https://github.com/crsmithdev/arrow/issues/415). I have added support for construction of arrow objects using the same KWARGS format as the datetime object. Also added test cases to ensure the functionality of the changes along with meeting the QA expectations of 100% statement coverage.