### PR TITLE
span_range() adds frame from start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ docs/_build/
 
 # VS Code
 .vscode/
+
+test.py

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -321,14 +321,12 @@ class Arrow(object):
 
         for r in _range:
             a,b = r.span(frame)
-            print("A initial: "+str(a))
             if exact:
                 a += timedelta(seconds=util.total_seconds(cls.fromdatetime(start)-_start))
                 b += timedelta(seconds=util.total_seconds(cls.fromdatetime(start)-_start))
                 if frame == "year" and calendar.isleap(start.year):
                     a-= timedelta(days=1)
                     b-= timedelta(days=1)
-            print("A exact  : "+str(a))
             if a == b or a == cls.fromdatetime(end):
                 continue
             if a < cls.fromdatetime(start):
@@ -337,7 +335,6 @@ class Arrow(object):
                 b = cls.fromdatetime(end - timedelta(milliseconds=.001))
             if a > b:
                 continue
-            print("A end    : "+str(a))
             x.append((a,b))
         return (r for r in x)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -312,11 +312,21 @@ class Arrow(object):
             (<Arrow [2013-05-05T17:00:00+00:00]>, <Arrow [2013-05-05T17:59:59.999999+00:00]>)
 
         '''
-
         tzinfo = cls._get_tzinfo(start.tzinfo if tz is None else tz)
-        start = cls.fromdatetime(start, tzinfo).span(frame)[0]
-        _range = cls.range(frame, start, end, tz, limit)
-        return (r.span(frame) for r in _range)
+        _start = cls.fromdatetime(start, tzinfo).span(frame)[0]
+        _range = cls.range(frame, _start, end, tz, limit)
+        x = []
+        for r in _range:
+            a = r.span(frame)[0]
+            b = r.span(frame)[1]
+            if a < cls.fromdatetime(start):
+                a = cls.fromdatetime(start)
+            if b > cls.fromdatetime(end):
+                b = cls.fromdatetime(end - timedelta(milliseconds=.001))
+            if a == b:
+                continue
+            x.append((a,b))
+        return (r for r in x)
 
     @classmethod
     @util.list_to_iter_deprecation

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -321,9 +321,14 @@ class Arrow(object):
 
         for r in _range:
             a,b = r.span(frame)
+            print("A initial: "+str(a))
             if exact:
                 a += timedelta(seconds=util.total_seconds(cls.fromdatetime(start)-_start))
                 b += timedelta(seconds=util.total_seconds(cls.fromdatetime(start)-_start))
+                if frame == "year" and calendar.isleap(start.year):
+                    a-= timedelta(days=1)
+                    b-= timedelta(days=1)
+            print("A exact  : "+str(a))
             if a == b or a == cls.fromdatetime(end):
                 continue
             if a < cls.fromdatetime(start):
@@ -332,6 +337,7 @@ class Arrow(object):
                 b = cls.fromdatetime(end - timedelta(milliseconds=.001))
             if a > b:
                 continue
+            print("A end    : "+str(a))
             x.append((a,b))
         return (r for r in x)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -268,7 +268,7 @@ class Arrow(object):
 
     @classmethod
     @util.list_to_iter_deprecation
-    def span_range(cls, frame, start, end, tz=None, limit=None):
+    def span_range(cls, frame, start, end, tz=None, limit=None, exact=False):
         ''' Returns an iterator of tuples, each :class:`Arrow <arrow.arrow.Arrow>` objects,
         representing a series of timespans between two inputs.
 
@@ -278,6 +278,8 @@ class Arrow(object):
         :param tz: (optional) A :ref:`timezone expression <tz-expr>`.  Defaults to
             ``start``'s timezone, or UTC if ``start`` is naive.
         :param limit: (optional) A maximum number of tuples to return.
+        :param exact: (optional) Will make the ranges outputted start and end with the offset
+            of the start and end times.
 
         **NOTE**: The ``end`` or ``limit`` must be provided.  Call with ``end`` alone to
         return the entire range.  Call with ``limit`` alone to return a maximum # of results from
@@ -316,8 +318,12 @@ class Arrow(object):
         _start = cls.fromdatetime(start, tzinfo).span(frame)[0]
         _range = cls.range(frame, _start, end, tz, limit)
         x = []
+
         for r in _range:
             a,b = r.span(frame)
+            if exact:
+                a += timedelta(seconds=util.total_seconds(cls.fromdatetime(start)-_start))
+                b += timedelta(seconds=util.total_seconds(cls.fromdatetime(start)-_start))
             if a == b or a == cls.fromdatetime(end):
                 continue
             if a < cls.fromdatetime(start):

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -268,7 +268,7 @@ class Arrow(object):
 
     @classmethod
     @util.list_to_iter_deprecation
-    def span_range(cls, frame, start, end, tz=None, limit=None, exact=False):
+    def span_range(cls, frame, start, end, tz=None, limit=None):
         ''' Returns an iterator of tuples, each :class:`Arrow <arrow.arrow.Arrow>` objects,
         representing a series of timespans between two inputs.
 
@@ -278,8 +278,6 @@ class Arrow(object):
         :param tz: (optional) A :ref:`timezone expression <tz-expr>`.  Defaults to
             ``start``'s timezone, or UTC if ``start`` is naive.
         :param limit: (optional) A maximum number of tuples to return.
-        :param exact: (optional) Will make the ranges outputted start and end with the offset
-            of the start and end times.
 
         **NOTE**: The ``end`` or ``limit`` must be provided.  Call with ``end`` alone to
         return the entire range.  Call with ``limit`` alone to return a maximum # of results from
@@ -824,8 +822,6 @@ class Arrow(object):
                 delta = sign * delta / float(60*60)
             elif granularity == 'day':
                 delta = sign * delta / float(60*60*24)
-            elif granularity == 'week':
-                delta = sign * delta / float(60*60*24*7)
             elif granularity == 'month':
                 delta = sign * delta / float(60*60*24*30.5)
             elif granularity == 'year':

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -330,6 +330,8 @@ class Arrow(object):
                 a = cls.fromdatetime(start)
             if b > cls.fromdatetime(end):
                 b = cls.fromdatetime(end - timedelta(milliseconds=.001))
+            if a > b:
+                continue
             x.append((a,b))
         return (r for r in x)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -304,12 +304,12 @@ class Arrow(object):
             >>> for r in arrow.Arrow.span_range('hour', start, end):
             ...     print(r)
             ...
-            (<Arrow [2013-05-05T12:00:00+00:00]>, <Arrow [2013-05-05T12:59:59.999999+00:00]>)
+            (<Arrow [2013-05-05T12:30:00+00:00]>, <Arrow [2013-05-05T12:59:59.999999+00:00]>)
             (<Arrow [2013-05-05T13:00:00+00:00]>, <Arrow [2013-05-05T13:59:59.999999+00:00]>)
             (<Arrow [2013-05-05T14:00:00+00:00]>, <Arrow [2013-05-05T14:59:59.999999+00:00]>)
             (<Arrow [2013-05-05T15:00:00+00:00]>, <Arrow [2013-05-05T15:59:59.999999+00:00]>)
             (<Arrow [2013-05-05T16:00:00+00:00]>, <Arrow [2013-05-05T16:59:59.999999+00:00]>)
-            (<Arrow [2013-05-05T17:00:00+00:00]>, <Arrow [2013-05-05T17:59:59.999999+00:00]>)
+            (<Arrow [2013-05-05T17:00:00+00:00]>, <Arrow [2013-05-05T17:14:59.999999+00:00]>)
 
         '''
         tzinfo = cls._get_tzinfo(start.tzinfo if tz is None else tz)
@@ -317,10 +317,7 @@ class Arrow(object):
         _range = cls.range(frame, _start, end, tz, limit)
         x = []
         for r in _range:
-            a = r.span(frame)[0]
-            b = r.span(frame)[1]
-            print(a)
-            print(b)
+            a,b = r.span(frame)
             if a == b or a == cls.fromdatetime(end):
                 continue
             if a < cls.fromdatetime(start):

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -319,12 +319,14 @@ class Arrow(object):
         for r in _range:
             a = r.span(frame)[0]
             b = r.span(frame)[1]
+            print(a)
+            print(b)
+            if a == b or a == cls.fromdatetime(end):
+                continue
             if a < cls.fromdatetime(start):
                 a = cls.fromdatetime(start)
             if b > cls.fromdatetime(end):
                 b = cls.fromdatetime(end - timedelta(milliseconds=.001))
-            if a == b:
-                continue
             x.append((a,b))
         return (r for r in x)
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -813,6 +813,8 @@ class Arrow(object):
                 delta = sign * delta / float(60*60)
             elif granularity == 'day':
                 delta = sign * delta / float(60*60*24)
+            elif granularity == 'week':
+                delta = sign * delta / float(60*60*24*7)
             elif granularity == 'month':
                 delta = sign * delta / float(60*60*24*30.5)
             elif granularity == 'year':

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -39,6 +39,8 @@ class Locale(object):
         'hours': '',
         'day': '',
         'days': '',
+        'week': '',
+        'weeks': '',
         'month': '',
         'months': '',
         'year': '',
@@ -200,6 +202,8 @@ class EnglishLocale(Locale):
         'hours': '{0} hours',
         'day': 'a day',
         'days': '{0} days',
+        'week': 'a week',
+        'weeks': '{0} weeks',
         'month': 'a month',
         'months': '{0} months',
         'year': 'a year',
@@ -236,7 +240,9 @@ class EnglishLocale(Locale):
 
 
 class ItalianLocale(Locale):
+
     names = ['it', 'it_it']
+
     past = '{0} fa'
     future = 'tra {0}'
 
@@ -249,6 +255,8 @@ class ItalianLocale(Locale):
         'hours': '{0} ore',
         'day': 'un giorno',
         'days': '{0} giorni',
+        'week': 'una settimana',
+        'weeks': '{0} settimane',
         'month': 'un mese',
         'months': '{0} mesi',
         'year': 'un anno',
@@ -270,7 +278,9 @@ class ItalianLocale(Locale):
 
 
 class SpanishLocale(Locale):
+
     names = ['es', 'es_es']
+
     past = 'hace {0}'
     future = 'en {0}'
 
@@ -283,6 +293,8 @@ class SpanishLocale(Locale):
         'hours': '{0} horas',
         'day': 'un día',
         'days': '{0} días',
+        'week': 'una semana',
+        'weeks': '{0} semanas',
         'month': 'un mes',
         'months': '{0} meses',
         'year': 'un año',
@@ -304,7 +316,9 @@ class SpanishLocale(Locale):
 
 
 class FrenchLocale(Locale):
+
     names = ['fr', 'fr_fr']
+
     past = 'il y a {0}'
     future = 'dans {0}'
 
@@ -317,6 +331,8 @@ class FrenchLocale(Locale):
         'hours': '{0} heures',
         'day': 'un jour',
         'days': '{0} jours',
+        'week': 'une semaine',
+        'weeks': '{0} semaines',
         'month': 'un mois',
         'months': '{0} mois',
         'year': 'un an',
@@ -355,6 +371,8 @@ class GreekLocale(Locale):
         'hours': '{0} ώρες',
         'day': 'μια μέρα',
         'days': '{0} μέρες',
+        'week': 'μια εβδομάδα',
+        'weeks': '{0} εβδομάδες',
         'month': 'ένα μήνα',
         'months': '{0} μήνες',
         'year': 'ένα χρόνο',
@@ -386,6 +404,8 @@ class JapaneseLocale(Locale):
         'hours': '{0}時間',
         'day': '1日',
         'days': '{0}日',
+        'week': '1週',
+        'weeks': '{0}週',
         'month': '1ヶ月',
         'months': '{0}ヶ月',
         'year': '1年',
@@ -417,6 +437,8 @@ class SwedishLocale(Locale):
         'hours': '{0} timmar',
         'day': 'en dag',
         'days': '{0} dagar',
+        'week': 'en vecka',
+        'weeks': '{0} veckor',
         'month': 'en månad',
         'months': '{0} månader',
         'year': 'ett år',
@@ -451,6 +473,8 @@ class FinnishLocale(Locale):
         'hours': ['{0} tuntia', '{0} tunnin'],
         'day': ['päivä', 'päivä'],
         'days': ['{0} päivää', '{0} päivän'],
+        'week': ['viikko', 'viikko'],
+        'weeks': ['{0} viikkoa', '{0} viikkoa'],
         'month': ['kuukausi', 'kuukauden'],
         'months': ['{0} kuukautta', '{0} kuukauden'],
         'year': ['vuosi', 'vuoden'],
@@ -504,6 +528,8 @@ class ChineseCNLocale(Locale):
         'hours': '{0}小时',
         'day': '1天',
         'days': '{0}天',
+        'week': '1周',
+        'weeks': '{0}周',
         'month': '1个月',
         'months': '{0}个月',
         'year': '1年',
@@ -535,6 +561,8 @@ class ChineseTWLocale(Locale):
         'hours': '{0}小時',
         'day': '1天',
         'days': '{0}天',
+        'week': '1周',
+        'weeks': '{0}周',
         'month': '1個月',
         'months': '{0}個月',
         'year': '1年',
@@ -566,6 +594,8 @@ class KoreanLocale(Locale):
         'hours': '{0}시간',
         'day': '1일',
         'days': '{0}일',
+        'week': '1주',
+        'weeks': '{0}주',
         'month': '1개월',
         'months': '{0}개월',
         'year': '1년',
@@ -598,6 +628,8 @@ class DutchLocale(Locale):
         'hours': '{0} uur',
         'day': 'een dag',
         'days': '{0} dagen',
+        'week': 'een week',
+        'weeks': '{0} weken',
         'month': 'een maand',
         'months': '{0} maanden',
         'year': 'een jaar',
@@ -1132,7 +1164,7 @@ class ArabicLocale(Locale):
 
     day_names = ['', 'الإثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت', 'الأحد']
     day_abbreviations = ['', 'إثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت', 'أحد']
-    
+
     def _format_timeframe(self, timeframe, delta):
         form = self.timeframes[timeframe]
         delta = abs(delta)
@@ -2194,6 +2226,6 @@ class EstonianLocale(Locale):
         else:
             form = form['past']
         return form.format(abs(delta))
-    
-    
+
+
 _locales = _map_locales()

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -39,8 +39,6 @@ class Locale(object):
         'hours': '',
         'day': '',
         'days': '',
-        'week': '',
-        'weeks': '',
         'month': '',
         'months': '',
         'year': '',
@@ -202,8 +200,6 @@ class EnglishLocale(Locale):
         'hours': '{0} hours',
         'day': 'a day',
         'days': '{0} days',
-        'week': 'a week',
-        'weeks': '{0} weeks',
         'month': 'a month',
         'months': '{0} months',
         'year': 'a year',
@@ -240,9 +236,7 @@ class EnglishLocale(Locale):
 
 
 class ItalianLocale(Locale):
-
     names = ['it', 'it_it']
-
     past = '{0} fa'
     future = 'tra {0}'
 
@@ -255,8 +249,6 @@ class ItalianLocale(Locale):
         'hours': '{0} ore',
         'day': 'un giorno',
         'days': '{0} giorni',
-        'week': 'una settimana',
-        'weeks': '{0} settimane',
         'month': 'un mese',
         'months': '{0} mesi',
         'year': 'un anno',
@@ -278,9 +270,7 @@ class ItalianLocale(Locale):
 
 
 class SpanishLocale(Locale):
-
     names = ['es', 'es_es']
-
     past = 'hace {0}'
     future = 'en {0}'
 
@@ -293,8 +283,6 @@ class SpanishLocale(Locale):
         'hours': '{0} horas',
         'day': 'un día',
         'days': '{0} días',
-        'week': 'una semana',
-        'weeks': '{0} semanas',
         'month': 'un mes',
         'months': '{0} meses',
         'year': 'un año',
@@ -316,9 +304,7 @@ class SpanishLocale(Locale):
 
 
 class FrenchLocale(Locale):
-
     names = ['fr', 'fr_fr']
-
     past = 'il y a {0}'
     future = 'dans {0}'
 
@@ -331,8 +317,6 @@ class FrenchLocale(Locale):
         'hours': '{0} heures',
         'day': 'un jour',
         'days': '{0} jours',
-        'week': 'une semaine',
-        'weeks': '{0} semaines',
         'month': 'un mois',
         'months': '{0} mois',
         'year': 'un an',
@@ -371,8 +355,6 @@ class GreekLocale(Locale):
         'hours': '{0} ώρες',
         'day': 'μια μέρα',
         'days': '{0} μέρες',
-        'week': 'μια εβδομάδα',
-        'weeks': '{0} εβδομάδες',
         'month': 'ένα μήνα',
         'months': '{0} μήνες',
         'year': 'ένα χρόνο',
@@ -404,8 +386,6 @@ class JapaneseLocale(Locale):
         'hours': '{0}時間',
         'day': '1日',
         'days': '{0}日',
-        'week': '1週',
-        'weeks': '{0}週',
         'month': '1ヶ月',
         'months': '{0}ヶ月',
         'year': '1年',
@@ -437,8 +417,6 @@ class SwedishLocale(Locale):
         'hours': '{0} timmar',
         'day': 'en dag',
         'days': '{0} dagar',
-        'week': 'en vecka',
-        'weeks': '{0} veckor',
         'month': 'en månad',
         'months': '{0} månader',
         'year': 'ett år',
@@ -473,8 +451,6 @@ class FinnishLocale(Locale):
         'hours': ['{0} tuntia', '{0} tunnin'],
         'day': ['päivä', 'päivä'],
         'days': ['{0} päivää', '{0} päivän'],
-        'week': ['viikko', 'viikko'],
-        'weeks': ['{0} viikkoa', '{0} viikkoa'],
         'month': ['kuukausi', 'kuukauden'],
         'months': ['{0} kuukautta', '{0} kuukauden'],
         'year': ['vuosi', 'vuoden'],
@@ -528,8 +504,6 @@ class ChineseCNLocale(Locale):
         'hours': '{0}小时',
         'day': '1天',
         'days': '{0}天',
-        'week': '1周',
-        'weeks': '{0}周',
         'month': '1个月',
         'months': '{0}个月',
         'year': '1年',
@@ -561,8 +535,6 @@ class ChineseTWLocale(Locale):
         'hours': '{0}小時',
         'day': '1天',
         'days': '{0}天',
-        'week': '1周',
-        'weeks': '{0}周',
         'month': '1個月',
         'months': '{0}個月',
         'year': '1年',
@@ -594,8 +566,6 @@ class KoreanLocale(Locale):
         'hours': '{0}시간',
         'day': '1일',
         'days': '{0}일',
-        'week': '1주',
-        'weeks': '{0}주',
         'month': '1개월',
         'months': '{0}개월',
         'year': '1년',
@@ -628,8 +598,6 @@ class DutchLocale(Locale):
         'hours': '{0} uur',
         'day': 'een dag',
         'days': '{0} dagen',
-        'week': 'een week',
-        'weeks': '{0} weken',
         'month': 'een maand',
         'months': '{0} maanden',
         'year': 'een jaar',


### PR DESCRIPTION
As per issue #498 , under "I think the return value should be: ", span_range() should add the frame to the start time, rather than its current behavior. An optional "exact" flag has been added to the span_range() function, and this new behavior will occur when it is set to true. 