### PR TITLE
Add additional timeframes translations for german language

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -812,6 +812,13 @@ class _DeutschLocaleCommonMixin(object):
         'years': '{0} Jahren',
     }
 
+    timeframes_only_distance = timeframes.copy()
+    timeframes_only_distance['minute'] = 'eine Minute'
+    timeframes_only_distance['hour'] = 'eine Stunde'
+    timeframes_only_distance['day'] = 'ein Tag'
+    timeframes_only_distance['month'] = 'ein Monat'
+    timeframes_only_distance['year'] = 'ein Jahr'
+
     month_names = [
         '', 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli',
         'August', 'September', 'Oktober', 'November', 'Dezember'
@@ -833,6 +840,21 @@ class _DeutschLocaleCommonMixin(object):
 
     def _ordinal_number(self, n):
         return '{}.'.format(n)
+
+    def describe(self, timeframe, delta=0, only_distance=False):
+        ''' Describes a delta within a timeframe in plain language.
+        :param timeframe: a string representing a timeframe.
+        :param delta: a quantity representing a delta in a timeframe.
+        :param only_distance: return only distance eg: "11 seconds" without "in" or "ago" keywords
+        '''
+
+        humanized = self.timeframes_only_distance[timeframe].format(trunc(abs(delta)))
+
+        if not only_distance:
+            humanized = self._format_timeframe(timeframe, delta)
+            humanized = self._format_relative(humanized, timeframe, delta)
+
+        return humanized
 
 
 class GermanLocale(_DeutschLocaleCommonMixin, Locale):

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -417,6 +417,18 @@ class GermanLocaleTests(Chai):
 
     def test_ordinal_number(self):
         assertEqual(self.locale.ordinal_number(1), '1.')
+    
+    def test_define(self):
+        assertEqual(self.locale.describe("minute", only_distance=True), 'eine Minute')
+        assertEqual(self.locale.describe("minute", only_distance=False), 'in einer Minute')
+        assertEqual(self.locale.describe("hour", only_distance=True), 'eine Stunde')
+        assertEqual(self.locale.describe("hour", only_distance=False), 'in einer Stunde')
+        assertEqual(self.locale.describe("day", only_distance=True), 'ein Tag')
+        assertEqual(self.locale.describe("day", only_distance=False), 'in einem Tag')
+        assertEqual(self.locale.describe("month", only_distance=True), 'ein Monat')
+        assertEqual(self.locale.describe("month", only_distance=False), 'in einem Monat')
+        assertEqual(self.locale.describe("year", only_distance=True), 'ein Jahr')
+        assertEqual(self.locale.describe("year", only_distance=False), 'in einem Jahr')
 
 
 class HungarianLocaleTests(Chai):


### PR DESCRIPTION
When using the `humanize` method of arrow lib with the "only_distance" option set to true, in german language there are some special cases which have to be translated different than if not using the option.
For example "in one hour" in german is "in einer Stunde", with "only_distance" set to true, it is "one hour" which is translated to "einer Stunde" at the moment. But it would be better to translate it like "eine Stunde".
This PR adds these special cases to the german localisation.