### PR TITLE
Fix humanize behavior with future days

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -802,7 +802,7 @@ class Arrow(object):
         else:
             raise TypeError()
 
-        delta = int(util.total_seconds(self._datetime - dt))
+        delta = int(round(util.total_seconds(self._datetime - dt)))
         sign = -1 if delta < 0 else 1
         diff = abs(delta)
         delta = diff

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1244,6 +1244,7 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later, only_distance=True), '2 days')
         assertEqual(later.humanize(self.now, only_distance=True), '2 days')
 
+        # Regression tests for humanize bug referenced in issue 541
         later = self.now.shift(days=3)
         assertEqual(later.humanize(), 'in 3 days')
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -1244,6 +1244,15 @@ class ArrowHumanizeTests(Chai):
         assertEqual(self.now.humanize(later, only_distance=True), '2 days')
         assertEqual(later.humanize(self.now, only_distance=True), '2 days')
 
+        later = self.now.shift(days=3)
+        assertEqual(later.humanize(), 'in 3 days')
+
+        later = self.now.shift(days=3, seconds=1)
+        assertEqual(later.humanize(), 'in 3 days')
+
+        later = self.now.shift(days=4)
+        assertEqual(later.humanize(), 'in 4 days')
+
     def test_month(self):
 
         later = self.now.shift(months=1)


### PR DESCRIPTION
After doing a little bit of debugging I found that the floating point delta value was being truncated by a cast to an int. If we simply round the number before casting this fixed the issue mentioned in https://github.com/crsmithdev/arrow/issues/541.

I have also included the test cases described in the issue thread.

Closes: #541 