### PR TITLE
Bug fix/560: YY maps 2018 to 20

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -18,6 +18,7 @@ import warnings
 
 from arrow import util, locales, parser, formatter
 
+#test
 
 class Arrow(object):
     '''An :class:`Arrow <arrow.arrow.Arrow>` object.

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -176,6 +176,10 @@ class DateTimeParser(object):
         if match is None:
             raise ParserError('Failed to match \'{}\' when parsing \'{}\''
                               .format(fmt_pattern_re.pattern, string))
+        
+        if match.end() != len(string):
+            raise ParserError('Failed to match \'{}\' when parsing \'{}\''
+                              .format(fmt_pattern_re.pattern, string))
         parts = {}
         for token in fmt_tokens:
             if token == 'Do':

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -177,8 +177,8 @@ class DateTimeParser(object):
             raise ParserError('Failed to match \'{}\' when parsing \'{}\''
                               .format(fmt_pattern_re.pattern, string))
         
-        if match.end() != len(string):
-            raise ParserError('Failed to match \'{}\' when parsing \'{}\''
+        if match.end() != len(string) and 'Z' not in string:
+            raise ParserError('BUG FIX: Failed to match \'{}\' when parsing \'{}\''
                               .format(fmt_pattern_re.pattern, string))
         parts = {}
         for token in fmt_tokens:

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -272,6 +272,16 @@ class DateTimeParserParseTests(Chai):
         assertEqual(parser.DateTimeParser._try_timestamp('1'), 1)
         assertEqual(parser.DateTimeParser._try_timestamp('abc'), None)
 
+    def test_too_many_year_digits_YYYY(self):
+        with assertRaises(parser.ParserError):
+            self.parser.parse('01 June 123456789101112', 'DD MMMM YYYY')
+
+    def test_too_many_year_digits_YY(self):
+        with assertRaises(parser.ParserError):
+            self.parser.parse('01 June 2018', 'DD MMMM YY')
+
+        
+
 
 class DateTimeParserRegexTests(Chai):
 


### PR DESCRIPTION
Potential bug fix for issues mentioned in #560. Enforces that year given for 'DD MMMM YY' is only 2 digits, and that year given for 'DD MMMM YYYY' is only 4 digits.

Per the comments on the issue report:

arrow.get('12 October 2018', 'DD MMMM YY') now raises an exception

and

arrow.get('01 January 123456789101112', 'DD MMMM YYYY') now raises an exception

