### PR TITLE
Cleaned up and updated setup.py

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -5,4 +5,3 @@ from .factory import ArrowFactory
 from .api import get, now, utcnow
 
 __version__ = "0.13.2"
-VERSION = __version__

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,15 @@
-import codecs
-import os.path
-import re
-import sys
+from setuptools import setup
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from arrow import __version__
 
-
-def fpath(name):
-    return os.path.join(os.path.dirname(__file__), name)
-
-
-def read(fname):
-    return codecs.open(fpath(fname), encoding="utf-8").read()
-
-
-def grep(attrname):
-    pattern = r'{}\W*=\W*"([^"]+)"'.format(attrname)
-    strval, = re.findall(pattern, file_text)
-    return strval
-
-
-file_text = read(fpath("arrow/__init__.py"))
+with open("README.rst", "r") as f:
+    readme = f.read()
 
 setup(
     name="arrow",
-    version=grep("__version__"),
+    version=__version__,
     description="Better dates and times for Python",
-    long_description=read(fpath("README.rst")),
+    long_description=readme,
     url="https://github.com/crsmithdev/arrow/",
     author="Chris Smith",
     author_email="crsmithdev@gmail.com",


### PR DESCRIPTION
I noticed `setup.py` was using some outdated Python methods that were most likely used to support `Python 2.6` and lower, but since `arrow` only support >=2.7, I think it is appropriate to cleanup setup.py to deprecate distutils and replace `fpath` and `codecs` with modern `open` syntax.

You can test this change with the following commands:
`make clean && make build27 && . local/bin/activate && python setup.py test`
`make clean && make build37 && . local/bin/activate && python setup.py test`