### PR TITLE
Fixed README to point to Travis master build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,29 +1,29 @@
 Arrow - Better dates & times for Python
 =======================================
 
-.. image:: https://travis-ci.org/crsmithdev/arrow.svg
-   :alt: build status
+.. image:: https://travis-ci.org/crsmithdev/arrow.svg?branch=master
+   :alt: Build Status
    :target: https://travis-ci.org/crsmithdev/arrow
 
 .. image:: https://codecov.io/github/crsmithdev/arrow/coverage.svg?branch=master
-   :target: https://codecov.io/github/crsmithdev/arrow
    :alt: Codecov
+   :target: https://codecov.io/github/crsmithdev/arrow
 
 .. image:: https://img.shields.io/pypi/v/arrow.svg
+   :alt: PyPI Version
    :target: https://pypi.python.org/pypi/arrow
-   :alt: arrow PyPI download
 
 .. image:: https://img.shields.io/pypi/pyversions/arrow.svg
+   :alt: Supported Python Versions
    :target: https://pypi.python.org/pypi/arrow
-   :alt: python versions
 
 .. image:: https://img.shields.io/pypi/l/arrow.svg
+   :alt: License
    :target: https://pypi.python.org/pypi/arrow
-   :alt: license
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :alt: Code Style: Black
    :target: https://github.com/python/black
-   :alt: code style
 
 Documentation: `arrow.readthedocs.io <https://arrow.readthedocs.io/en/latest/>`_
 ---------------------------------------------------------------------------------


### PR DESCRIPTION
The Travis CI build is currently shown as failing because the badge is not set to point to the master branch builds, but rather all Travis builds. Since we are working on some fixes in other branches that are currently failing, it is best to point the badge to the latest passing master Travis build. I also adjusted the orderings of the targets in the `README.rst` file.