### PR TITLE
Allow factory.get() to construct with kwargs

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -137,6 +137,15 @@ class ArrowFactory(object):
         locale = kwargs.get("locale", "en_us")
         tz = kwargs.get("tzinfo", None)
 
+        # if kwargs given, send to constructor unless only tzinfo provided.
+        if len(kwargs) > 1:
+            arg_count = 3
+        if len(kwargs) == 1:
+            if isinstance(tz, tzinfo):
+                pass
+            else:
+                arg_count = 3
+
         # () -> now, @ utc.
         if arg_count == 0:
             if isinstance(tz, tzinfo):

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -141,9 +141,7 @@ class ArrowFactory(object):
         if len(kwargs) > 1:
             arg_count = 3
         if len(kwargs) == 1:
-            if isinstance(tz, tzinfo):
-                pass
-            else:
+            if not isinstance(tz, tzinfo):
                 arg_count = 3
 
         # () -> now, @ utc.

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -221,6 +221,18 @@ class GetTests(Chai):
             self.factory.get(2013, 1, 1), datetime(2013, 1, 1, tzinfo=tz.tzutc())
         )
 
+    def test_three_kwargs(self):
+
+        self.assertEqual(
+            self.factory.get(year=2016, month=7, day=14),
+            datetime(2016, 7, 14, 0, 0, tzinfo=tz.tzutc()),
+        )
+
+    def test_insufficient_kwargs(self):
+
+        with self.assertRaises(TypeError):
+            self.factory.get(year=2016)
+
 
 class UtcNowTests(Chai):
     def setUp(self):

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -221,6 +221,21 @@ class GetTests(Chai):
             self.factory.get(2013, 1, 1), datetime(2013, 1, 1, tzinfo=tz.tzutc())
         )
 
+    def test_full_kwargs(self):
+
+        self.assertEqual(
+            self.factory.get(
+                year=2016,
+                month=7,
+                day=14,
+                hour=7,
+                minute=16,
+                second=45,
+                microsecond=631092,
+            ),
+            datetime(2016, 7, 14, 7, 16, 45, 631092, tzinfo=tz.tzutc()),
+        )
+
     def test_three_kwargs(self):
 
         self.assertEqual(
@@ -232,6 +247,19 @@ class GetTests(Chai):
 
         with self.assertRaises(TypeError):
             self.factory.get(year=2016)
+
+        with self.assertRaises(TypeError):
+            self.factory.get(year=2016, month=7)
+
+    def test_locale_kwarg_only(self):
+
+        with self.assertRaises(TypeError):
+            self.factory.get(locale="ja")
+
+    def test_locale_with_tzinfo(self):
+
+        with self.assertRaises(TypeError):
+            self.factory.get(locale="ja", tzinfo=tz.gettz("Asia/Tokyo"))
 
 
 class UtcNowTests(Chai):


### PR DESCRIPTION
@jadchaar this is the small snippet of code I showed you a while back on zoom.

Essentially this lets us handle kwargs properly like the Arrow() constructor already does without having to do a ton of refactoring. Let me know if you think it's worth using as a quick fix.

```shell
arrow.get(year=2016, month=7, day=14)
<Arrow [2016-07-14T00:00:00+00:00]>
``` 

ref #415 