### PR TITLE
Add meridians to Spanish locale

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -376,6 +376,8 @@ class SpanishLocale(Locale):
         "years": "{0} años",
     }
 
+    meridians = {"am": "am", "pm": "pm", "AM": "AM", "PM": "PM"}
+
     month_names = [
         "",
         "enero",

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -727,6 +727,15 @@ class DateTimeParserMeridiansTests(Chai):
             parser_.parse("2013-01-01 5 DU", "YYYY-MM-DD h A"), datetime(2013, 1, 1, 17)
         )
 
+    # regression check for https://github.com/crsmithdev/arrow/issues/607
+    def test_es_meridians(self):
+        parser_ = parser.DateTimeParser("es")
+
+        self.assertEqual(
+            parser_.parse("Junio 30, 2019 - 08:00 pm", "MMMM DD, YYYY - hh:mm a"),
+            datetime(2019, 6, 30, 20, 0),
+        )
+
 
 class DateTimeParserMonthOrdinalDayTests(Chai):
     def setUp(self):


### PR DESCRIPTION
```shell
arrow.get('Junio 30, 2019 - 08:00 pm', "MMMM DD, YYYY - hh:mm a", locale="es")
<Arrow [2019-06-30T20:00:00+00:00]>
```

/cc @NestorTejero
ref #607 