### PR TITLE
Official Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
           cache:
               directories:
                   - $HOME/.cache/pre-commit
-    allow_failures:
-        - python: 3.8-dev
-          env: TOXENV=py38
 install: pip install -U codecov tox
 script: tox
 after_success: codecov


### PR DESCRIPTION
Since Python 3.8 is now in beta, I think it is appropriate to remove it from `allow_failures`.