### PR TITLE
Allow ms and μs timestamps

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1378,7 +1378,9 @@ class Arrow(object):
             return timestamp / 1000000.0
 
         raise ValueError(
-            "specified timestamp '{}' too big, use seconds, ms or ns".format(timestamp)
+            "specified timestamp '{}' too big, use seconds, milliseconds (ms) or microseconds (us)".format(
+                timestamp
+            )
         )
 
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1367,13 +1367,19 @@ class Arrow(object):
 
         try:
             timestamp = float(timestamp)
-            if timestamp < Constants.BIGGEST_TS:
-                return timestamp
-            if timestamp < Constants.BIGGEST_TS * 1000.0:
-                return timestamp / 1000.0
-            return timestamp / 1000000.0
-        except Exception:
+        except ValueError:
             raise ValueError("cannot parse '{}' as a timestamp".format(timestamp))
+
+        if timestamp < Constants.MAX_TIMESTAMP:
+            return timestamp
+        if timestamp < Constants.MAX_TIMESTAMP_MS:
+            return timestamp / 1000.0
+        if timestamp < Constants.MAX_TIMESTAMP_NS:
+            return timestamp / 1000000.0
+
+        raise ValueError(
+            "specified timestamp '{}' too big, use seconds, ms or ns".format(timestamp)
+        )
 
 
 Arrow.min = Arrow.fromdatetime(datetime.min)

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -17,6 +17,7 @@ from dateutil import tz as dateutil_tz
 from dateutil.relativedelta import relativedelta
 
 from arrow import formatter, locales, parser, util
+from arrow.util import Constants
 
 
 class Arrow(object):
@@ -1365,7 +1366,12 @@ class Arrow(object):
     def _get_timestamp_from_input(timestamp):
 
         try:
-            return float(timestamp)
+            timestamp = float(timestamp)
+            if timestamp < Constants.YEAR_9999_TS:
+                return timestamp
+            if timestamp < Constants.YEAR_9999_TS * 1000.0:
+                return timestamp / 1000.0
+            return timestamp / 1000000.0
         except Exception:
             raise ValueError("cannot parse '{}' as a timestamp".format(timestamp))
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1367,7 +1367,7 @@ class Arrow(object):
 
         try:
             timestamp = float(timestamp)
-        except ValueError:
+        except Exception:
             raise ValueError("cannot parse '{}' as a timestamp".format(timestamp))
 
         if timestamp < Constants.MAX_TIMESTAMP:

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1367,9 +1367,9 @@ class Arrow(object):
 
         try:
             timestamp = float(timestamp)
-            if timestamp < Constants.YEAR_9999_TS:
+            if timestamp < Constants.BIGGEST_TS:
                 return timestamp
-            if timestamp < Constants.YEAR_9999_TS * 1000.0:
+            if timestamp < Constants.BIGGEST_TS * 1000.0:
                 return timestamp / 1000.0
             return timestamp / 1000000.0
         except Exception:

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1374,7 +1374,7 @@ class Arrow(object):
             return timestamp
         if timestamp < Constants.MAX_TIMESTAMP_MS:
             return timestamp / 1000.0
-        if timestamp < Constants.MAX_TIMESTAMP_NS:
+        if timestamp < Constants.MAX_TIMESTAMP_US:
             return timestamp / 1000000.0
 
         raise ValueError(

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -97,7 +97,7 @@ class list_to_iter_shim(list):
 class Constants:
     MAX_TIMESTAMP = time.mktime(datetime.max.timetuple())
     MAX_TIMESTAMP_MS = MAX_TIMESTAMP * 1000.0
-    MAX_TIMESTAMP_NS = MAX_TIMESTAMP * 1000000.0
+    MAX_TIMESTAMP_US = MAX_TIMESTAMP * 1000000.0
 
 
 __all__ = ["total_seconds", "is_timestamp", "isstr", "list_to_iter_shim", "Constants"]

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import sys
+import time
 import warnings
 from datetime import datetime
 
@@ -94,7 +95,7 @@ class list_to_iter_shim(list):
 
 
 class Constants:
-    YEAR_9999_TS = datetime(9999, 1, 1).timestamp()
+    BIGGEST_TS = time.mktime(datetime.max.timetuple())
 
 
 __all__ = ["total_seconds", "is_timestamp", "isstr", "list_to_iter_shim", "Constants"]

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -95,7 +95,9 @@ class list_to_iter_shim(list):
 
 
 class Constants:
-    BIGGEST_TS = time.mktime(datetime.max.timetuple())
+    MAX_TIMESTAMP = time.mktime(datetime.max.timetuple())
+    MAX_TIMESTAMP_MS = MAX_TIMESTAMP * 1000.0
+    MAX_TIMESTAMP_NS = MAX_TIMESTAMP * 1000000.0
 
 
 __all__ = ["total_seconds", "is_timestamp", "isstr", "list_to_iter_shim", "Constants"]

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import sys
 import warnings
+from datetime import datetime
 
 
 def total_seconds(td):  # pragma: no cover
@@ -92,4 +93,8 @@ class list_to_iter_shim(list):
     del _wrap_method
 
 
-__all__ = ["total_seconds", "is_timestamp", "isstr", "list_to_iter_shim"]
+class Constants:
+    YEAR_9999_TS = datetime(9999, 1, 1).timestamp()
+
+
+__all__ = ["total_seconds", "is_timestamp", "isstr", "list_to_iter_shim", "Constants"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Create from timestamps (ints or floats, or strings that convert to a float):
     >>> arrow.get('1367900664.152325')
     <Arrow [2013-05-07T04:24:24.152325+00:00]>
 
-Also supported microsecond (ms) and nanosecond (μs) timestamps:
+Also supported millisecond (ms, 10^-3 s) and microsecond (μs, 10^-6 s) timestamps:
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,22 @@ Create from timestamps (ints or floats, or strings that convert to a float):
     >>> arrow.get('1367900664.152325')
     <Arrow [2013-05-07T04:24:24.152325+00:00]>
 
+Also supported microsecond (ms) and nanosecond (μs) timestamps:
+
+.. code-block:: python
+
+    >>> arrow.get(1367900664000)
+    <Arrow [2013-05-07T04:24:24+00:00]>
+
+    >>> arrow.get('1367900664000')
+    <Arrow [2013-05-07T04:24:24+00:00]>
+
+    >>> arrow.get(1367900664000000)
+    <Arrow [2013-05-07T04:24:24+00:00]>
+
+    >>> arrow.get('1367900664000000')
+    <Arrow [2013-05-07T04:24:24+00:00]>
+
 Use a naive or timezone-aware datetime, or flexibly specify a timezone:
 
 .. code-block:: python

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -57,10 +57,8 @@ class GetTests(Chai):
         self.assertEqual(self.factory.get(timestamp), timestamp_dt)
         self.assertEqual(self.factory.get(str(timestamp)), timestamp_dt)
 
-        # Issue 216
         timestamp = "99999999999999999999999999"
-        # Python 3 raises `OverflowError`, Python 2 raises `ValueError`
-        with self.assertRaises((OverflowError, ValueError)):
+        with self.assertRaises(ValueError):
             self.factory.get(timestamp)
 
         timestamp = 1563286714.0

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -66,9 +66,12 @@ class GetTests(Chai):
         timestamp = 1563286714.0
         timestamp_ms = timestamp * 1000.0
         timestamp_us = timestamp * 1000000.0
+        timestamp_ps = timestamp * 1000000000.0
         timestamp_dt = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
         self.assertEqual(self.factory.get(timestamp_ms), timestamp_dt)
         self.assertEqual(self.factory.get(timestamp_us), timestamp_dt)
+        with self.assertRaises(ValueError):
+            self.factory.get(timestamp_ps)
 
     def test_one_arg_arrow(self):
 

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -63,10 +63,10 @@ class GetTests(Chai):
         with self.assertRaises((OverflowError, ValueError)):
             self.factory.get(timestamp)
 
-        timestamp_dt = datetime.utcnow().replace(tzinfo=tz.tzutc())
-        timestamp = timestamp_dt.timestamp()
+        timestamp = time.time()
         timestamp_ms = timestamp * 1000.0
         timestamp_us = timestamp * 1000000.0
+        timestamp_dt = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
         self.assertEqual(self.factory.get(timestamp_ms), timestamp_dt)
         self.assertEqual(self.factory.get(timestamp_us), timestamp_dt)
 

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -63,6 +63,13 @@ class GetTests(Chai):
         with self.assertRaises((OverflowError, ValueError)):
             self.factory.get(timestamp)
 
+        timestamp_dt = datetime.utcnow().replace(tzinfo=tz.tzutc())
+        timestamp = timestamp_dt.timestamp()
+        timestamp_ms = timestamp * 1000.0
+        timestamp_us = timestamp * 1000000.0
+        self.assertEqual(self.factory.get(timestamp_ms), timestamp_dt)
+        self.assertEqual(self.factory.get(timestamp_us), timestamp_dt)
+
     def test_one_arg_arrow(self):
 
         arw = self.factory.utcnow()

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -63,7 +63,7 @@ class GetTests(Chai):
         with self.assertRaises((OverflowError, ValueError)):
             self.factory.get(timestamp)
 
-        timestamp = time.time()
+        timestamp = 1563286714.0
         timestamp_ms = timestamp * 1000.0
         timestamp_us = timestamp * 1000000.0
         timestamp_dt = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())


### PR DESCRIPTION
Now available usage like this:
```
>>> arrow.get(1563286714)
<Arrow [2019-07-16T14:18:34+00:00]>

>>> arrow.get(1563286714123)
<Arrow [2019-07-16T14:18:34.123000+00:00]>

>>> arrow.get(1563286714123456)
<Arrow [2019-07-16T14:18:34.123456+00:00]>
```

Update of this PR: https://github.com/crsmithdev/arrow/pull/358
For fixing this issue: https://github.com/crsmithdev/arrow/issues/357