### PR TITLE
Move backports from extra_requires to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    keywords="arrow date time datetime",
+    keywords="arrow date time datetime timestamp timezone",
     project_urls={
         "Repository": "https://github.com/crsmithdev/arrow",
         "Bug Reports": "https://github.com/crsmithdev/arrow/issues",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with io.open("arrow/_version.py", "r", encoding="utf-8") as f:
 setup(
     name="arrow",
     version=about["__version__"],
-    description="Better dates and times for Python",
+    description="Better dates & times for Python",
     long_description=readme,
     long_description_content_type="text/x-rst",
     url="https://arrow.readthedocs.io/en/latest/",
@@ -23,8 +23,10 @@ setup(
     packages=["arrow"],
     zip_safe=False,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-    install_requires=["python-dateutil"],
-    extras_require={":python_version=='2.7'": ["backports.functools_lru_cache>=1.2.1"]},
+    install_requires=[
+        "python-dateutil",
+        "backports.functools_lru_cache;python_version=='2.7'",
+    ],
     test_suite="tests",
     tests_require=["chai"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
         "python-dateutil",
-        "backports.functools_lru_cache;python_version=='2.7'",
+        "backports.functools_lru_cache>=1.2.1;python_version=='2.7'",
     ],
     test_suite="tests",
     tests_require=["chai"],


### PR DESCRIPTION
This is now the official method for conditionally requiring python versions as documented here: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies. Pytest does the same here: https://github.com/pytest-dev/pytest/blob/master/setup.py#L11.

Addresses: https://github.com/crsmithdev/arrow/issues/495