### PR TITLE
Fix regression when tzinfo kwarg is a string

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -157,7 +157,7 @@ class ArrowFactory(object):
         if len(kwargs) > 1:
             arg_count = 3
         if len(kwargs) == 1:
-            if not isinstance(tz, tzinfo):
+            if not tz:
                 arg_count = 3
 
         # () -> now, @ utc.

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -243,6 +243,12 @@ class GetTests(Chai):
             datetime(2016, 7, 14, 0, 0, tzinfo=tz.tzutc()),
         )
 
+    def test_tzinfo_string_kwargs(self):
+        result = self.factory.get("2019072807", "YYYYMMDDHH", tzinfo="UTC")
+        self.assertEqual(
+            result._datetime, datetime(2019, 7, 28, 7, 0, 0, 0, tzinfo=tz.tzutc())
+        )
+
     def test_insufficient_kwargs(self):
 
         with self.assertRaises(TypeError):


### PR DESCRIPTION
In v 0.14.2 passing a date string, a format string and tzinfo kwarg where the value is a string worked correctly. This usage pattern broke in 0.14.3. This restores the previous behavior.