### PR TITLE
Removed deprecated replace shift functionality

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 
 import calendar
 import sys
-import warnings
 from datetime import datetime, timedelta, tzinfo
 from math import trunc
 
@@ -580,33 +579,17 @@ class Arrow(object):
         """
 
         absolute_kwargs = {}
-        relative_kwargs = {}  # TODO: DEPRECATED; remove in next release
 
         for key, value in kwargs.items():
 
             if key in self._ATTRS:
                 absolute_kwargs[key] = value
-            elif key in self._ATTRS_PLURAL or key in ["weeks", "quarters"]:
-                # TODO: DEPRECATED
-                warnings.warn(
-                    "replace() with plural property to shift value "
-                    "is deprecated, use shift() instead",
-                    DeprecationWarning,
-                )
-                relative_kwargs[key] = value
             elif key in ["week", "quarter"]:
                 raise AttributeError("setting absolute {} is not supported".format(key))
             elif key != "tzinfo":
                 raise AttributeError('unknown attribute: "{}"'.format(key))
 
-        # core datetime does not support quarters, translate to months.
-        relative_kwargs.setdefault("months", 0)
-        relative_kwargs["months"] += (
-            relative_kwargs.pop("quarters", 0) * self._MONTHS_PER_QUARTER
-        )
-
         current = self._datetime.replace(**absolute_kwargs)
-        current += relativedelta(**relative_kwargs)  # TODO: DEPRECATED
 
         tzinfo = kwargs.get("tzinfo")
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -228,28 +228,6 @@ class ArrowComparisonTests(Chai):
         self.assertFalse(self.arrow != self.arrow.datetime)
         self.assertTrue(self.arrow != "abc")
 
-    def test_deprecated_replace(self):
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            self.arrow.replace(weeks=1)
-            # Verify some things
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
-            assert "deprecated" in str(w[-1].message)
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            self.arrow.replace(hours=1)
-            # Verify some things
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
-            assert "deprecated" in str(w[-1].message)
-
     def test_gt(self):
 
         arrow_cmp = self.arrow.shift(minutes=1)
@@ -499,79 +477,6 @@ class ArrowReplaceTests(Chai):
         self.assertEqual(arw.replace(minute=1), arrow.Arrow(2013, 5, 5, 12, 1, 45))
         self.assertEqual(arw.replace(second=1), arrow.Arrow(2013, 5, 5, 12, 30, 1))
 
-    def test_replace_shift(self):
-
-        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
-
-        # This is all scheduled for deprecation
-        self.assertEqual(arw.replace(years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45))
-        self.assertEqual(arw.replace(quarters=1), arrow.Arrow(2013, 8, 5, 12, 30, 45))
-        self.assertEqual(
-            arw.replace(quarters=1, months=1), arrow.Arrow(2013, 9, 5, 12, 30, 45)
-        )
-        self.assertEqual(arw.replace(months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45))
-        self.assertEqual(arw.replace(weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45))
-        self.assertEqual(arw.replace(days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45))
-        self.assertEqual(arw.replace(hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45))
-        self.assertEqual(arw.replace(minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45))
-        self.assertEqual(arw.replace(seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46))
-        self.assertEqual(
-            arw.replace(microseconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 45, 1)
-        )
-
-    def test_replace_shift_negative(self):
-
-        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
-
-        # This is all scheduled for deprecation
-        self.assertEqual(arw.replace(years=-1), arrow.Arrow(2012, 5, 5, 12, 30, 45))
-        self.assertEqual(arw.replace(quarters=-1), arrow.Arrow(2013, 2, 5, 12, 30, 45))
-        self.assertEqual(
-            arw.replace(quarters=-1, months=-1), arrow.Arrow(2013, 1, 5, 12, 30, 45)
-        )
-        self.assertEqual(arw.replace(months=-1), arrow.Arrow(2013, 4, 5, 12, 30, 45))
-        self.assertEqual(arw.replace(weeks=-1), arrow.Arrow(2013, 4, 28, 12, 30, 45))
-        self.assertEqual(arw.replace(days=-1), arrow.Arrow(2013, 5, 4, 12, 30, 45))
-        self.assertEqual(arw.replace(hours=-1), arrow.Arrow(2013, 5, 5, 11, 30, 45))
-        self.assertEqual(arw.replace(minutes=-1), arrow.Arrow(2013, 5, 5, 12, 29, 45))
-        self.assertEqual(arw.replace(seconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44))
-        self.assertEqual(
-            arw.replace(microseconds=-1), arrow.Arrow(2013, 5, 5, 12, 30, 44, 999999)
-        )
-
-    def test_replace_quarters_bug(self):
-
-        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
-
-        # The value of the last-read argument was used instead of the ``quarters`` argument.
-        # Recall that the keyword argument dict, like all dicts, is unordered, so only certain
-        # combinations of arguments would exhibit this.
-        self.assertEqual(
-            arw.replace(quarters=0, years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, microseconds=1),
-            arrow.Arrow(2013, 5, 5, 12, 30, 45, 1),
-        )
-
     def test_replace_tzinfo(self):
 
         arw = arrow.Arrow.utcnow().to("US/Eastern")
@@ -707,39 +612,6 @@ class ArrowShiftTests(Chai):
         self.assertEqual(arw.shift(weekday=SU(-1)), arw)
         self.assertEqual(
             arw.shift(weekday=SU(-2)), arrow.Arrow(2013, 4, 28, 12, 30, 45)
-        )
-
-    def test_shift_quarters_bug(self):
-
-        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
-
-        # The value of the last-read argument was used instead of the ``quarters`` argument.
-        # Recall that the keyword argument dict, like all dicts, is unordered, so only certain
-        # combinations of arguments would exhibit this.
-        self.assertEqual(
-            arw.replace(quarters=0, years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46)
-        )
-        self.assertEqual(
-            arw.replace(quarters=0, microseconds=1),
-            arrow.Arrow(2013, 5, 5, 12, 30, 45, 1),
         )
 
 

--- a/tests/arrow_tests.py
+++ b/tests/arrow_tests.py
@@ -614,6 +614,39 @@ class ArrowShiftTests(Chai):
             arw.shift(weekday=SU(-2)), arrow.Arrow(2013, 4, 28, 12, 30, 45)
         )
 
+    def test_shift_quarters_bug(self):
+
+        arw = arrow.Arrow(2013, 5, 5, 12, 30, 45)
+
+        # The value of the last-read argument was used instead of the ``quarters`` argument.
+        # Recall that the keyword argument dict, like all dicts, is unordered, so only certain
+        # combinations of arguments would exhibit this.
+        self.assertEqual(
+            arw.shift(quarters=0, years=1), arrow.Arrow(2014, 5, 5, 12, 30, 45)
+        )
+        self.assertEqual(
+            arw.shift(quarters=0, months=1), arrow.Arrow(2013, 6, 5, 12, 30, 45)
+        )
+        self.assertEqual(
+            arw.shift(quarters=0, weeks=1), arrow.Arrow(2013, 5, 12, 12, 30, 45)
+        )
+        self.assertEqual(
+            arw.shift(quarters=0, days=1), arrow.Arrow(2013, 5, 6, 12, 30, 45)
+        )
+        self.assertEqual(
+            arw.shift(quarters=0, hours=1), arrow.Arrow(2013, 5, 5, 13, 30, 45)
+        )
+        self.assertEqual(
+            arw.shift(quarters=0, minutes=1), arrow.Arrow(2013, 5, 5, 12, 31, 45)
+        )
+        self.assertEqual(
+            arw.shift(quarters=0, seconds=1), arrow.Arrow(2013, 5, 5, 12, 30, 46)
+        )
+        self.assertEqual(
+            arw.shift(quarters=0, microseconds=1),
+            arrow.Arrow(2013, 5, 5, 12, 30, 45, 1),
+        )
+
 
 class ArrowRangeTests(Chai):
     def test_year(self):


### PR DESCRIPTION
I am going through some of the issues mentioned in [this blog post from 2016](https://blog.eustace.io/please-stop-using-arrow.html) and I think it is time that we finally remove the ability to shift from the `replace` function in arrow. A deprecation warning has been in place since 2016, so I think it is an appropriate time to remove this functionality.