### PR TITLE
Updated HISTORY to reflect deprecation changes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,8 +3,8 @@
 ### 0.14.5
 
 - [NEW] Added Afrikaans locale.
-- [CHANGE] Removed deprecated replace shift functionality.
-- [FIX] Fixed bug that occurred when factory.get() was passed a locale kwarg.
+- [CHANGE] Removed deprecated `replace` shift functionality. Users looking to pass plural properties to the `replace` function to shift values should use `shift` instead.
+- [FIX] Fixed bug that occurred when `factory.get()` was passed a locale kwarg.
 
 ### 0.14.4
 


### PR DESCRIPTION
I added a bit more context to the history file to better describe the deprecation pushed in `v0.15.0`.