### PR TITLE
Removed instances of replace with plural properties from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Example Usage
     >>> utc
     <Arrow [2013-05-11T21:23:58.970460+00:00]>
 
-    >>> utc = utc.replace(hours=-1)
+    >>> utc = utc.shift(hours=-1)
     >>> utc
     <Arrow [2013-05-11T20:23:58.970460+00:00]>
 


### PR DESCRIPTION
@catwell pointed out that we still have some references to the deprecated replace functionality with plural properties in the docs. I could only find one instance in the docs, but I made sure to replace it with `shift`.