### PR TITLE
Add French locale for week granularity

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -445,6 +445,8 @@ class FrenchLocale(Locale):
         "hours": "{0} heures",
         "day": "un jour",
         "days": "{0} jours",
+        "week": "une semaine",
+        "weeks": "{0} semaines",
         "month": "un mois",
         "months": "{0} mois",
         "year": "un an",


### PR DESCRIPTION
Following [release 0.14.6](https://github.com/crsmithdev/arrow/releases/tag/0.14.6), here the French translations for week/weeks.