### PR TITLE
0.15.0 regression - Support negative numbers in the timestamp regular expression

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -45,7 +45,7 @@ class DateTimeParser(object):
     _TZ_NAME_RE = re.compile(r"\w[\w+\-/]+")
     # NOTE: timestamps cannot be parsed from natural language strings (by removing the ^...$) because it will
     # break cases like "15 Jul 2000" and a format list (see issue #447)
-    _TIMESTAMP_RE = re.compile(r"^\d+\.?\d+$")
+    _TIMESTAMP_RE = re.compile(r"^-?\d+\.?\d+$")
     _TIME_RE = re.compile(r"^(\d{2})(?:\:?(\d{2}))?(?:\:?(\d{2}))?(?:([\.\,])(\d+))?$")
 
     _BASE_INPUT_RE_MAP = {

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -224,6 +224,12 @@ class DateTimeParserParseTests(Chai):
             self.parser.parse("{:f}123456".format(float_timestamp), "X"), self.expected
         )
 
+        negative_timestamp = -1565358758
+        self.expected = datetime.fromtimestamp(negative_timestamp, tz=tz_utc)
+        self.assertEqual(
+            self.parser.parse("{:d}".format(negative_timestamp), "X"), self.expected
+        )        
+
         # NOTE: timestamps cannot be parsed from natural language strings (by removing the ^...$) because it will
         # break cases like "15 Jul 2000" and a format list (see issue #447)
         with self.assertRaises(ParserError):

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -228,7 +228,7 @@ class DateTimeParserParseTests(Chai):
         self.expected = datetime.fromtimestamp(negative_timestamp, tz=tz_utc)
         self.assertEqual(
             self.parser.parse("{:d}".format(negative_timestamp), "X"), self.expected
-        )        
+        )
 
         # NOTE: timestamps cannot be parsed from natural language strings (by removing the ^...$) because it will
         # break cases like "15 Jul 2000" and a format list (see issue #447)


### PR DESCRIPTION
This solves https://github.com/crsmithdev/arrow/issues/662

Currently arrow does not allow you to pass in negative numbers for seconds relative to epoch when using strings. This patch is an attempt to fix this.