### PR TITLE
Add Week/Weeks/Various Seconds to Portuguese and Brazilian Portuguese

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1777,7 +1777,8 @@ class PortugueseLocale(Locale):
 
     timeframes = {
         "now": "agora",
-        "seconds": "segundos",
+        "second": "um segundo",
+        "seconds": "{0} segundos",
         "minute": "um minuto",
         "minutes": "{0} minutos",
         "hour": "uma hora",
@@ -1845,7 +1846,8 @@ class BrazilianPortugueseLocale(PortugueseLocale):
 
     timeframes = {
         "now": "agora",
-        "seconds": "segundos",
+        "second": "um segundo",
+        "seconds": "{0} segundos",
         "minute": "um minuto",
         "minutes": "{0} minutos",
         "hour": "uma hora",

--- a/tests/locales_tests.py
+++ b/tests/locales_tests.py
@@ -836,3 +836,47 @@ class EstonianLocaleTests(Chai):
         self.assertEqual(self.locale._format_timeframe("year", -1), "üks aasta")
         self.assertEqual(self.locale._format_timeframe("years", -4), "4 aastat")
         self.assertEqual(self.locale._format_timeframe("years", -14), "14 aastat")
+
+
+class PortugueseLocaleTests(Chai):
+    def setUp(self):
+        super(PortugueseLocaleTests, self).setUp()
+
+        self.locale = locales.PortugueseLocale()
+
+    def test_format_timeframe(self):
+        self.assertEqual(self.locale._format_timeframe("now", 0), "agora")
+        self.assertEqual(self.locale._format_timeframe("second", 1), "um segundo")
+        self.assertEqual(self.locale._format_timeframe("seconds", 30), "30 segundos")
+        self.assertEqual(self.locale._format_timeframe("minute", 1), "um minuto")
+        self.assertEqual(self.locale._format_timeframe("minutes", 40), "40 minutos")
+        self.assertEqual(self.locale._format_timeframe("hour", 1), "uma hora")
+        self.assertEqual(self.locale._format_timeframe("hours", 23), "23 horas")
+        self.assertEqual(self.locale._format_timeframe("day", 1), "um dia")
+        self.assertEqual(self.locale._format_timeframe("days", 12), "12 dias")
+        self.assertEqual(self.locale._format_timeframe("month", 1), "um mês")
+        self.assertEqual(self.locale._format_timeframe("months", 11), "11 meses")
+        self.assertEqual(self.locale._format_timeframe("year", 1), "um ano")
+        self.assertEqual(self.locale._format_timeframe("years", 12), "12 anos")
+
+
+class BrazilianLocaleTests(Chai):
+    def setUp(self):
+        super(BrazilianLocaleTests, self).setUp()
+
+        self.locale = locales.BrazilianPortugueseLocale()
+
+    def test_format_timeframe(self):
+        self.assertEqual(self.locale._format_timeframe("now", 0), "agora")
+        self.assertEqual(self.locale._format_timeframe("second", 1), "um segundo")
+        self.assertEqual(self.locale._format_timeframe("seconds", 30), "30 segundos")
+        self.assertEqual(self.locale._format_timeframe("minute", 1), "um minuto")
+        self.assertEqual(self.locale._format_timeframe("minutes", 40), "40 minutos")
+        self.assertEqual(self.locale._format_timeframe("hour", 1), "uma hora")
+        self.assertEqual(self.locale._format_timeframe("hours", 23), "23 horas")
+        self.assertEqual(self.locale._format_timeframe("day", 1), "um dia")
+        self.assertEqual(self.locale._format_timeframe("days", 12), "12 dias")
+        self.assertEqual(self.locale._format_timeframe("month", 1), "um mês")
+        self.assertEqual(self.locale._format_timeframe("months", 11), "11 meses")
+        self.assertEqual(self.locale._format_timeframe("year", 1), "um ano")
+        self.assertEqual(self.locale._format_timeframe("years", 12), "12 anos")


### PR DESCRIPTION
This pull request adds humanization to for Week and Weeks to Porguese and Brazilian, also changes "seconds" so that you can now have the equivalent to "1 second" and "N seconds" in those locales.

Tests for Portuguese and Brazilian are also added.

Any requests please do ask 