### PR TITLE
Renamed ISO-8601 to ISO 8601 in docs to conform with Wikipedia page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -239,7 +239,7 @@ The following will work in v0.15.0:
 
 - [NEW] struct_time addition. (mhworth)
 - [NEW] Version grep (eirnym)
-- [NEW] Default to ISO-8601 format (emonty)
+- [NEW] Default to ISO 8601 format (emonty)
 - [NEW] Raise TypeError on comparison (sniekamp)
 - [NEW] Adding Macedonian(mk) locale (krisfremen)
 - [FIX] Fix for ISO seconds and fractional seconds (sdispater) (andrewelkins)
@@ -321,7 +321,7 @@ The following will work in v0.15.0:
 0.4.0
 -----
 
-- [NEW] Format-free ISO-8601 parsing in factory ``get`` method
+- [NEW] Format-free ISO 8601 parsing in factory ``get`` method
 - [NEW] Support for 'week' / 'weeks' in ``span``, ``range``, ``span_range``, ``floor`` and ``ceil``
 - [NEW] Support for 'weeks' in ``replace``
 - [NEW] Norwegian locale (Martinp)
@@ -332,7 +332,7 @@ The following will work in v0.15.0:
 - [FIX] Corrected plurals of Ukrainian and Russian nouns (Catchagain)
 - [CHANGE] Old 0.1 ``arrow`` module method removed
 - [CHANGE] Dropped timestamp support in ``range`` and ``span_range`` (never worked correctly)
-- [CHANGE] Dropped parsing of single string as tz string in factory ``get`` method (replaced by ISO-8601)
+- [CHANGE] Dropped parsing of single string as tz string in factory ``get`` method (replaced by ISO 8601)
 
 0.3.5
 -----

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Python's standard library and some other low-level modules have near-complete da
 - Too many types: date, time, datetime, tzinfo, timedelta, relativedelta, etc.
 - Timezones and timestamp conversions are verbose and unpleasant
 - Timezone naivety is the norm
-- Gaps in functionality: ISO-8601 parsing, timespans, humanization
+- Gaps in functionality: ISO 8601 parsing, timespans, humanization
 
 Features
 --------
@@ -52,7 +52,7 @@ Features
 - Provides super-simple creation options for many common input scenarios
 - :code:`shift` method with support for relative offsets, including weeks
 - Formats and parses strings automatically
-- Wide support for ISO-8601
+- Wide support for ISO 8601
 - Timezone conversion
 - Timestamp available as a property
 - Generates time spans, ranges, floors and ceilings for time frames ranging from microsecond to year

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -40,7 +40,7 @@ class Arrow(object):
 
         - A ``tzinfo`` object.
         - A ``str`` describing a timezone, similar to 'US/Pacific', or 'Europe/Berlin'.
-        - A ``str`` in ISO-8601 style, as in '+07:00'.
+        - A ``str`` in ISO 8601 style, as in '+07:00'.
         - A ``str``, one of the following:  'local', 'utc', 'UTC'.
 
     Usage::
@@ -423,7 +423,7 @@ class Arrow(object):
 
             - A ``tzinfo`` object.
             - A ``str`` describing a timezone, similar to 'US/Pacific', or 'Europe/Berlin'.
-            - A ``str`` in ISO-8601 style, as in '+07:00'.
+            - A ``str`` in ISO 8601 style, as in '+07:00'.
             - A ``str``, one of the following:  'local', 'utc', 'UTC'.
 
         Usage:

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -69,12 +69,12 @@ class ArrowFactory(object):
             >>> arrow.get(1367992474)
             <Arrow [2013-05-08T05:54:34+00:00]>
 
-        **One** ISO-8601-formatted ``str``, to parse it::
+        **One** ISO 8601-formatted ``str``, to parse it::
 
             >>> arrow.get('2013-09-29T01:26:43.830580')
             <Arrow [2013-09-29T01:26:43.830580+00:00]>
 
-        **One** ISO-8601-formatted ``str``, in basic format, to parse it::
+        **One** ISO 8601-formatted ``str``, in basic format, to parse it::
 
             >>> arrow.get('20160413T133656.456289')
             <Arrow [2016-04-13T13:36:56.456289+00:00]>

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -110,7 +110,7 @@ class DateTimeParser(object):
                 self._generate_pattern_re
             )
 
-    # TODO: since we support more than ISO-8601, we should rename this function
+    # TODO: since we support more than ISO 8601, we should rename this function
     # IDEA: break into multiple functions
     def parse_iso(self, datetime_string):
         # TODO: add a flag to normalize whitespace (useful in logs, ref issue #421)
@@ -128,7 +128,7 @@ class DateTimeParser(object):
         has_time = has_space_divider or has_t_divider
         has_tz = False
 
-        # date formats (ISO-8601 and others) to test against
+        # date formats (ISO 8601 and others) to test against
         # NOTE: YYYYMM is omitted to avoid confusion with YYMMDD (no longer part of ISO 8601, but is still often used)
         formats = [
             "YYYY-MM-DD",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ Search a date in a string:
     >>> arrow.get('June was born in May 1980', 'MMMM YYYY')
     <Arrow [1980-05-01T00:00:00+00:00]>
 
-Some ISO-8601 compliant strings are recognized and parsed without a format string:
+Some ISO 8601 compliant strings are recognized and parsed without a format string:
 
     >>> arrow.get('2013-09-30T15:34:00.000-07:00')
     <Arrow [2013-09-30T15:34:00-07:00]>


### PR DESCRIPTION
Source: https://en.wikipedia.org/wiki/ISO_8601