### PR TITLE
Test TzinfoParser against full timezone database

### DIFF
--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -6,12 +6,20 @@ import os
 import time
 from datetime import datetime
 
+import pytz
 from chai import Chai
 from dateutil import tz
+from dateutil.zoneinfo import get_zonefile_instance
 
 from arrow import parser
 from arrow.constants import MAX_TIMESTAMP_US
 from arrow.parser import DateTimeParser, ParserError, ParserMatchError
+
+
+def make_full_tz_list():
+    dateutil_zones = set(get_zonefile_instance().zones)
+    pytz_zones = set(pytz.all_timezones)
+    return dateutil_zones.union(pytz_zones)
 
 
 class DateTimeParserTests(Chai):
@@ -332,23 +340,7 @@ class DateTimeParserParseTests(Chai):
         )
 
     def test_parse_tz_name_zzz(self):
-        for tz_name in (
-            # best solution would be to test on every available tz name from
-            # the tz database but it is actually tricky to retrieve them from
-            # dateutil so here is short list that should match all
-            # naming patterns/conventions in used tz database
-            "Africa/Tripoli",
-            "America/Port_of_Spain",
-            "Australia/LHI",
-            "Etc/GMT-11",
-            "Etc/GMT0",
-            "Etc/UCT",
-            "Etc/GMT+9",
-            "GMT+0",
-            "CST6CDT",
-            "GMT-0",
-            "W-SU",
-        ):
+        for tz_name in make_full_tz_list():
             self.expected = datetime(2013, 1, 1, tzinfo=tz.gettz(tz_name))
             self.assertEqual(
                 self.parser.parse("2013-01-01 %s" % tz_name, "YYYY-MM-DD ZZZ"),


### PR DESCRIPTION
Zones are retrieved via [dateutil](https://dateutil.readthedocs.io/en/stable/zoneinfo.html?highlight=zoneinfofile#dateutil.zoneinfo.get_zonefile_instance) (though `ZoneFileInfo.zones` is not documented), and [pytz](http://pytz.sourceforge.net/#helpers) and are used in existing test `tests.parser_tests:DateTimeParserParseTests.test_parse_tz_name_zzz`.

Closes: crsmithdev/arrow#657