### PR TITLE
add "week" translation for vi-vn locale

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1995,6 +1995,8 @@ class VietnameseLocale(Locale):
         "hours": "{0} giờ",
         "day": "một ngày",
         "days": "{0} ngày",
+        "week": "một tuần",
+        "weeks": "{0} tuần",
         "month": "một tháng",
         "months": "{0} tháng",
         "year": "một năm",


### PR DESCRIPTION
```ValueError: Humanization of the 'weeks' granularity is not currently translated in the 'vi_vn' locale. Please consider making a contribution to this locale.```