### PR TITLE
Update formatter tests for tz abbreviations

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -10,7 +10,7 @@ from arrow import locales, util
 
 
 class DateTimeFormatter(object):
-
+    # TODO: test against full timezone DB
     _FORMAT_RE = re.compile(
         r"(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X)"
     )

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -474,7 +474,6 @@ class DateTimeParser(object):
 
 
 class TzinfoParser(object):
-    # TODO: test against full timezone DB
     _TZINFO_RE = re.compile(r"^([\+\-])?(\d{2})(?:\:?(\d{2}))?$")
 
     @classmethod

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -122,7 +122,7 @@ class DateTimeFormatterFormatTokenTests(Chai):
     def test_timezone_formatter(self):
 
         tz_map = {
-            # 'BRST': 'America/Sao_Paulo', TODO investigate why this fails
+            "CST": "Asia/Shanghai",
             "CET": "Europe/Berlin",
             "JST": "Asia/Tokyo",
             "PST": "US/Pacific",


### PR DESCRIPTION
`"BRST"` was never going to work in this test so I've substituted `"CST"` for now, this is a minor fix until we can test fully against the tz database.

closes #554 