### PR TITLE
Test formatter against full timezone database #693

### DIFF
--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -5,8 +5,15 @@ from datetime import datetime
 import pytz
 from chai import Chai
 from dateutil import tz as dateutil_tz
+from dateutil.zoneinfo import get_zonefile_instance
 
 from arrow import formatter
+
+
+def make_full_tz_list():
+    dateutil_zones = set(get_zonefile_instance().zones)
+    pytz_zones = set(pytz.all_timezones)
+    return dateutil_zones.union(pytz_zones)
 
 
 class DateTimeFormatterFormatTokenTests(Chai):
@@ -121,18 +128,13 @@ class DateTimeFormatterFormatTokenTests(Chai):
 
     def test_timezone_formatter(self):
 
-        tz_map = {
-            "CST": "Asia/Shanghai",
-            "CET": "Europe/Berlin",
-            "JST": "Asia/Tokyo",
-            "PST": "US/Pacific",
-        }
-
-        for abbreviation, full_name in tz_map.items():
+        for full_name in make_full_tz_list():
             # This test will fail if we use "now" as date as soon as we change from/to DST
             dt = datetime(1986, 2, 14, tzinfo=pytz.timezone("UTC")).replace(
                 tzinfo=dateutil_tz.gettz(full_name)
             )
+            abbreviation = dt.tzname()
+
             result = self.formatter._format_token(dt, "ZZZ")
             self.assertEqual(result, abbreviation)
 

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -5,15 +5,9 @@ from datetime import datetime
 import pytz
 from chai import Chai
 from dateutil import tz as dateutil_tz
-from dateutil.zoneinfo import get_zonefile_instance
 
 from arrow import formatter
-
-
-def make_full_tz_list():
-    dateutil_zones = set(get_zonefile_instance().zones)
-    pytz_zones = set(pytz.all_timezones)
-    return dateutil_zones.union(pytz_zones)
+from tests.utils import make_full_tz_list
 
 
 class DateTimeFormatterFormatTokenTests(Chai):

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -7,7 +7,8 @@ from chai import Chai
 from dateutil import tz as dateutil_tz
 
 from arrow import formatter
-from tests.utils import make_full_tz_list
+
+from .utils import make_full_tz_list
 
 
 class DateTimeFormatterFormatTokenTests(Chai):

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -6,20 +6,13 @@ import os
 import time
 from datetime import datetime
 
-import pytz
 from chai import Chai
 from dateutil import tz
-from dateutil.zoneinfo import get_zonefile_instance
 
 from arrow import parser
 from arrow.constants import MAX_TIMESTAMP_US
 from arrow.parser import DateTimeParser, ParserError, ParserMatchError
-
-
-def make_full_tz_list():
-    dateutil_zones = set(get_zonefile_instance().zones)
-    pytz_zones = set(pytz.all_timezones)
-    return dateutil_zones.union(pytz_zones)
+from tests.utils import make_full_tz_list
 
 
 class DateTimeParserTests(Chai):

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -12,7 +12,8 @@ from dateutil import tz
 from arrow import parser
 from arrow.constants import MAX_TIMESTAMP_US
 from arrow.parser import DateTimeParser, ParserError, ParserMatchError
-from tests.utils import make_full_tz_list
+
+from .utils import make_full_tz_list
 
 
 class DateTimeParserTests(Chai):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+import pytz
+from dateutil.zoneinfo import get_zonefile_instance
+
+
+def make_full_tz_list():
+    dateutil_zones = set(get_zonefile_instance().zones)
+    pytz_zones = set(pytz.all_timezones)
+    return dateutil_zones.union(pytz_zones)


### PR DESCRIPTION
Closes #693 
Similar to #657, zones are retrieved via dateutil and pytz, and are used in existing test. The abbreviation is also retrieved from the existing test, using the method `tzname()`.