### PR TITLE
Add support for negative timestamps on Windows (#675)

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -156,7 +156,7 @@ class Arrow(object):
                 "The provided timestamp '{}' is invalid.".format(timestamp)
             )
 
-        dt = datetime.fromtimestamp(float(timestamp), tzinfo)
+        dt = util.safe_fromtimestamp(float(timestamp), tzinfo)
 
         return cls(
             dt.year,
@@ -182,7 +182,7 @@ class Arrow(object):
                 "The provided timestamp '{}' is invalid.".format(timestamp)
             )
 
-        dt = datetime.utcfromtimestamp(float(timestamp))
+        dt = util.safe_utcfromtimestamp(float(timestamp))
 
         return cls(
             dt.year,

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from dateutil import tz
 
-from arrow import locales
+from arrow import locales, util
 from arrow.constants import MAX_TIMESTAMP, MAX_TIMESTAMP_MS, MAX_TIMESTAMP_US
 
 try:
@@ -368,7 +368,7 @@ class DateTimeParser(object):
         timestamp = parts.get("timestamp")
 
         if timestamp is not None:
-            return datetime.fromtimestamp(timestamp, tz=tz.tzutc())
+            return util.safe_fromtimestamp(timestamp, tz=tz.tzutc())
 
         expanded_timestamp = parts.get("expanded_timestamp")
 
@@ -386,7 +386,7 @@ class DateTimeParser(object):
                         )
                     )
 
-            return datetime.fromtimestamp(expanded_timestamp, tz=tz.tzutc())
+            return util.safe_fromtimestamp(expanded_timestamp, tz=tz.tzutc())
 
         day_of_year = parts.get("day_of_year")
 

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -2,6 +2,11 @@
 from __future__ import absolute_import
 
 import datetime
+import math
+import os
+import time
+
+import dateutil
 
 
 def total_seconds(td):  # pragma: no cover
@@ -21,6 +26,42 @@ def is_timestamp(value):
         return True
     except ValueError:
         return False
+
+
+def datetime_from_timestamp(timestamp, tz=None):
+    """Computes datetime from timestamp. Supports negative timestamps on Windows platform."""
+    sec_frac, sec = math.modf(timestamp)
+    dt = datetime.datetime(1970, 1, 1, tzinfo=dateutil.tz.tzutc()) + datetime.timedelta(
+        seconds=sec, microseconds=sec_frac * 1e6
+    )
+    if tz is None:
+        tz = dateutil.tz.tzlocal()
+    if tz == dateutil.tz.tzlocal():
+        # because datetime.astimezone does not work on Windows for tzlocal() and dates before the 1970-01-01
+        # take timestamp from appropriate time of the year, because of daylight saving time changes
+        ts = time.mktime(dt.replace(year=1970).timetuple())
+        dt += datetime.datetime.fromtimestamp(ts) - datetime.datetime.utcfromtimestamp(
+            ts
+        )
+        return dt.replace(tzinfo=dateutil.tz.tzlocal())
+    else:
+        return dt.astimezone(tz)
+
+
+def safe_utcfromtimestamp(timestamp, os_name=os.name):
+    """ datetime.utcfromtimestamp alternative which supports negatvie timestamps on Windows platform."""
+    if os_name == "nt" and timestamp < 0:
+        return datetime_from_timestamp(timestamp, dateutil.tz.tzutc())
+    else:
+        return datetime.datetime.utcfromtimestamp(timestamp)
+
+
+def safe_fromtimestamp(timestamp, tz=None, os_name=os.name):
+    """ datetime.fromtimestamp alternative which supports negatvie timestamps on Windows platform."""
+    if os_name == "nt" and timestamp < 0:
+        return datetime_from_timestamp(timestamp, tz)
+    else:
+        return datetime.datetime.fromtimestamp(timestamp, tz)
 
 
 # Credit to https://stackoverflow.com/a/1700069
@@ -57,4 +98,12 @@ except NameError:  # pragma: no cover
         return isinstance(s, str)
 
 
-__all__ = ["total_seconds", "is_timestamp", "isstr", "iso_to_gregorian"]
+__all__ = [
+    "total_seconds",
+    "is_timestamp",
+    "isstr",
+    "iso_to_gregorian",
+    "datetime_from_timestamp",
+    "safe_utcfromtimestamp",
+    "safe_fromtimestamp",
+]

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -28,30 +28,30 @@ def is_timestamp(value):
         return False
 
 
-def datetime_from_timestamp(timestamp, tz=None):
+def windows_datetime_from_timestamp(timestamp, tz=None):
     """Computes datetime from timestamp. Supports negative timestamps on Windows platform."""
     sec_frac, sec = math.modf(timestamp)
     dt = datetime.datetime(1970, 1, 1, tzinfo=dateutil.tz.tzutc()) + datetime.timedelta(
         seconds=sec, microseconds=sec_frac * 1e6
     )
-    if tz is None:
-        tz = dateutil.tz.tzlocal()
-    if tz == dateutil.tz.tzlocal():
-        # because datetime.astimezone does not work on Windows for tzlocal() and dates before the 1970-01-01
-        # take timestamp from appropriate time of the year, because of daylight saving time changes
-        ts = time.mktime(dt.replace(year=1970).timetuple())
-        dt += datetime.datetime.fromtimestamp(ts) - datetime.datetime.utcfromtimestamp(
-            ts
-        )
-        return dt.replace(tzinfo=dateutil.tz.tzlocal())
-    else:
-        return dt.astimezone(tz)
+    if tz is not None:
+        if tz == dateutil.tz.tzlocal():
+            # because datetime.astimezone does not work on Windows for tzlocal() and dates before the 1970-01-01
+            # take timestamp from appropriate time of the year, because of daylight saving time changes
+            ts = time.mktime(dt.replace(year=1970).timetuple())
+            dt += datetime.datetime.fromtimestamp(
+                ts
+            ) - datetime.datetime.utcfromtimestamp(ts)
+            dt = dt.replace(tzinfo=dateutil.tz.tzlocal())
+        else:
+            dt = dt.astimezone(tz)
+    return dt
 
 
 def safe_utcfromtimestamp(timestamp, os_name=os.name):
     """ datetime.utcfromtimestamp alternative which supports negatvie timestamps on Windows platform."""
     if os_name == "nt" and timestamp < 0:
-        return datetime_from_timestamp(timestamp, dateutil.tz.tzutc())
+        return windows_datetime_from_timestamp(timestamp, dateutil.tz.tzutc())
     else:
         return datetime.datetime.utcfromtimestamp(timestamp)
 
@@ -59,7 +59,10 @@ def safe_utcfromtimestamp(timestamp, os_name=os.name):
 def safe_fromtimestamp(timestamp, tz=None, os_name=os.name):
     """ datetime.fromtimestamp alternative which supports negatvie timestamps on Windows platform."""
     if os_name == "nt" and timestamp < 0:
-        return datetime_from_timestamp(timestamp, tz)
+        if tz is None:
+            # because datetime.fromtimestamp default is local time
+            tz = dateutil.tz.tzlocal()
+        return windows_datetime_from_timestamp(timestamp, tz)
     else:
         return datetime.datetime.fromtimestamp(timestamp, tz)
 
@@ -103,7 +106,7 @@ __all__ = [
     "is_timestamp",
     "isstr",
     "iso_to_gregorian",
-    "datetime_from_timestamp",
+    "windows_datetime_from_timestamp",
     "safe_utcfromtimestamp",
     "safe_fromtimestamp",
 ]

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import calendar
-import os
 import time
 from datetime import datetime
 
@@ -11,7 +10,7 @@ from chai import Chai
 from dateutil import tz
 from dateutil.zoneinfo import get_zonefile_instance
 
-from arrow import parser
+from arrow import parser, util
 from arrow.constants import MAX_TIMESTAMP_US
 from arrow.parser import DateTimeParser, ParserError, ParserMatchError
 
@@ -234,23 +233,19 @@ class DateTimeParserParseTests(Chai):
             self.parser.parse("{:f}123456".format(float_timestamp), "X"), self.expected
         )
 
-        # NOTE: negative timestamps cannot be handled by datetime on Window
-        # Must use timedelta to handle them. ref: https://stackoverflow.com/questions/36179914
-        if os.name != "nt":
-            # regression test for issue #662
-            negative_int_timestamp = -int_timestamp
-            self.expected = datetime.fromtimestamp(negative_int_timestamp, tz=tz_utc)
-            self.assertEqual(
-                self.parser.parse("{:d}".format(negative_int_timestamp), "X"),
-                self.expected,
-            )
+        # regression test for issue #662
+        negative_int_timestamp = -int_timestamp
+        self.expected = util.safe_fromtimestamp(negative_int_timestamp, tz=tz_utc)
+        self.assertEqual(
+            self.parser.parse("{:d}".format(negative_int_timestamp), "X"), self.expected
+        )
 
-            negative_float_timestamp = -float_timestamp
-            self.expected = datetime.fromtimestamp(negative_float_timestamp, tz=tz_utc)
-            self.assertEqual(
-                self.parser.parse("{:f}".format(negative_float_timestamp), "X"),
-                self.expected,
-            )
+        negative_float_timestamp = -float_timestamp
+        self.expected = util.safe_fromtimestamp(negative_float_timestamp, tz=tz_utc)
+        self.assertEqual(
+            self.parser.parse("{:f}".format(negative_float_timestamp), "X"),
+            self.expected,
+        )
 
         # NOTE: timestamps cannot be parsed from natural language strings (by removing the ^...$) because it will
         # break cases like "15 Jul 2000" and a format list (see issue #447)

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from chai import Chai
 from dateutil import tz
+from mock import patch
 
 from arrow import util
 
@@ -80,26 +81,18 @@ class UtilTests(Chai):
         )
         self.assertEqual(result, expected)
 
+    @patch.object(util, "os_name", "nt")
     def test_safe_utcfromtimestamp_negative_nt(self):
         timestamp = -1572204340.6460679
-        result = util.safe_utcfromtimestamp(timestamp, os_name="nt").replace(
-            tzinfo=tz.tzutc()
-        )
+        result = util.safe_utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
         expected = datetime(1920, 3, 7, 4, 34, 19, 353932, tzinfo=tz.tzutc())
         self.assertEqual(result, expected)
 
+    @patch.object(util, "os_name", "nt")
     def test_safe_fromtimestamp_negative_nt(self):
         timestamp = -1572204340.6460679
-        result = util.safe_fromtimestamp(
-            timestamp, tz.gettz("Europe/Paris"), os_name="nt"
-        )
+        result = util.safe_fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
         expected = datetime(
             1920, 3, 7, 5, 34, 19, 353932, tzinfo=tz.gettz("Europe/Paris")
         )
-        self.assertEqual(result, expected)
-
-    def test_safe_fromtimestamp_negative_nt_no_tz(self):
-        timestamp = -1572204340.6460679
-        result = util.safe_fromtimestamp(timestamp, os_name="nt")
-        expected = util.windows_datetime_from_timestamp(timestamp, tz.tzlocal())
         self.assertEqual(result, expected)

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -36,15 +36,15 @@ class UtilTests(Chai):
         with self.assertRaises(ValueError):
             util.iso_to_gregorian(2013, 8, 0)
 
-    def test_datetime_from_timestamp(self):
+    def test_windows_datetime_from_timestamp(self):
         timestamp = 1572204340.6460679
-        result = util.datetime_from_timestamp(timestamp)
+        result = util.windows_datetime_from_timestamp(timestamp)
         expected = datetime.fromtimestamp(timestamp).replace(tzinfo=tz.tzlocal())
         self.assertEqual(result, expected)
 
-    def test_datetime_from_timestamp_utc(self):
+    def test_windows_datetime_from_timestamp_utc(self):
         timestamp = 1572204340.6460679
-        result = util.datetime_from_timestamp(timestamp, tz.tzutc())
+        result = util.windows_datetime_from_timestamp(timestamp, tz.tzutc())
         expected = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
         self.assertEqual(result, expected)
 
@@ -96,4 +96,10 @@ class UtilTests(Chai):
         expected = datetime(
             1920, 3, 7, 5, 34, 19, 353932, tzinfo=tz.gettz("Europe/Paris")
         )
+        self.assertEqual(result, expected)
+
+    def test_safe_fromtimestamp_negative_nt_no_tz(self):
+        timestamp = -1572204340.6460679
+        result = util.safe_fromtimestamp(timestamp, os_name="nt")
+        expected = util.windows_datetime_from_timestamp(timestamp, tz.tzlocal())
         self.assertEqual(result, expected)

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import time
+from datetime import datetime
 
 from chai import Chai
+from dateutil import tz
 
 from arrow import util
 
@@ -33,3 +35,65 @@ class UtilTests(Chai):
 
         with self.assertRaises(ValueError):
             util.iso_to_gregorian(2013, 8, 0)
+
+    def test_datetime_from_timestamp(self):
+        timestamp = 1572204340.6460679
+        result = util.datetime_from_timestamp(timestamp)
+        expected = datetime.fromtimestamp(timestamp).replace(tzinfo=tz.tzlocal())
+        self.assertEqual(result, expected)
+
+    def test_datetime_from_timestamp_utc(self):
+        timestamp = 1572204340.6460679
+        result = util.datetime_from_timestamp(timestamp, tz.tzutc())
+        expected = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
+        self.assertEqual(result, expected)
+
+    def test_safe_utcfromtimestamp(self):
+        timestamp = 1572204340.6460679
+        result = util.safe_utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
+        expected = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
+        self.assertEqual(result, expected)
+
+    def test_safe_fromtimestamp_default_tz(self):
+        timestamp = 1572204340.6460679
+        result = util.safe_fromtimestamp(timestamp).replace(tzinfo=tz.tzlocal())
+        expected = datetime.fromtimestamp(timestamp).replace(tzinfo=tz.tzlocal())
+        self.assertEqual(result, expected)
+
+    def test_safe_fromtimestamp_paris_tz(self):
+        timestamp = 1572204340.6460679
+        result = util.safe_fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
+        expected = datetime.fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
+        self.assertEqual(result, expected)
+
+    def test_safe_utcfromtimestamp_negative(self):
+        timestamp = -1572204340.6460679
+        result = util.safe_utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
+        expected = datetime(1920, 3, 7, 4, 34, 19, 353932, tzinfo=tz.tzutc())
+        self.assertEqual(result, expected)
+
+    def test_safe_fromtimestamp_negative(self):
+        timestamp = -1572204340.6460679
+        result = util.safe_fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
+        expected = datetime(
+            1920, 3, 7, 5, 34, 19, 353932, tzinfo=tz.gettz("Europe/Paris")
+        )
+        self.assertEqual(result, expected)
+
+    def test_safe_utcfromtimestamp_negative_nt(self):
+        timestamp = -1572204340.6460679
+        result = util.safe_utcfromtimestamp(timestamp, os_name="nt").replace(
+            tzinfo=tz.tzutc()
+        )
+        expected = datetime(1920, 3, 7, 4, 34, 19, 353932, tzinfo=tz.tzutc())
+        self.assertEqual(result, expected)
+
+    def test_safe_fromtimestamp_negative_nt(self):
+        timestamp = -1572204340.6460679
+        result = util.safe_fromtimestamp(
+            timestamp, tz.gettz("Europe/Paris"), os_name="nt"
+        )
+        expected = datetime(
+            1920, 3, 7, 5, 34, 19, 353932, tzinfo=tz.gettz("Europe/Paris")
+        )
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Adds support for negative timestamps on Windows by computing the `datetime` directly using `timedelta`.  This is method is only used as a fallback, so on other platforms or with positive timestamps the `datetime.fromtimestamp` or `datetime.utcfromtimestamp` methods are used.
Closes #675 