### PR TITLE
Add ParserError to the module exports.

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -3,3 +3,4 @@ from ._version import __version__
 from .api import get, now, utcnow
 from .arrow import Arrow
 from .factory import ArrowFactory
+from .parser import ParserError


### PR DESCRIPTION
Adding ParserError to the module exports allows users to easily catch that specific error. It also eases lookup of that error for tools like PyCharm.