### PR TITLE
Allow factory.get() to construct from a timestamp and timezone

### DIFF
--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -168,6 +168,10 @@ class ArrowFactory(object):
             if arg is None:
                 return self.type.utcnow()
 
+            # try (int, float) -> from timestamp with tz
+            elif not isstr(arg) and is_timestamp(arg) and tz is not None:
+                return self.type.fromtimestamp(arg, tzinfo=tz)
+
             # try (int, float) -> utc, from timestamp.
             elif not isstr(arg) and is_timestamp(arg):
                 return self.type.utcfromtimestamp(arg)

--- a/arrow/factory.py
+++ b/arrow/factory.py
@@ -169,12 +169,11 @@ class ArrowFactory(object):
                 return self.type.utcnow()
 
             # try (int, float) -> from timestamp with tz
-            elif not isstr(arg) and is_timestamp(arg) and tz is not None:
-                return self.type.fromtimestamp(arg, tzinfo=tz)
-
-            # try (int, float) -> utc, from timestamp.
             elif not isstr(arg) and is_timestamp(arg):
-                return self.type.utcfromtimestamp(arg)
+                if tz is None:
+                    # set to UTC by default
+                    tz = dateutil_tz.tzutc()
+                return self.type.fromtimestamp(arg, tzinfo=tz)
 
             # (Arrow) -> from the object's datetime.
             elif isinstance(arg, Arrow):

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -73,6 +73,16 @@ class GetTests(Chai):
         with self.assertRaises((OverflowError, ValueError)):
             self.factory.get(timestamp)
 
+    def test_one_arg_timestamp_with_tzinfo(self):
+
+        int_timestamp = int(time.time())
+        timestamp_dt = datetime.utcfromtimestamp(int_timestamp).astimezone(
+            tz.gettz("US/Pacific")
+        )
+        timezone = tz.gettz("US/Pacific")
+
+        assertDtEqual(self.factory.get(int_timestamp, tzinfo=timezone), timestamp_dt)
+
     def test_one_arg_arrow(self):
 
         arw = self.factory.utcnow()

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -75,13 +75,13 @@ class GetTests(Chai):
 
     def test_one_arg_timestamp_with_tzinfo(self):
 
-        int_timestamp = int(time.time())
-        timestamp_dt = datetime.fromtimestamp(int_timestamp, tz=tz.tzutc()).astimezone(
+        timestamp = time.time()
+        timestamp_dt = datetime.fromtimestamp(timestamp, tz=tz.tzutc()).astimezone(
             tz.gettz("US/Pacific")
         )
         timezone = tz.gettz("US/Pacific")
 
-        assertDtEqual(self.factory.get(int_timestamp, tzinfo=timezone), timestamp_dt)
+        assertDtEqual(self.factory.get(timestamp, tzinfo=timezone), timestamp_dt)
 
     def test_one_arg_arrow(self):
 

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -76,7 +76,7 @@ class GetTests(Chai):
     def test_one_arg_timestamp_with_tzinfo(self):
 
         int_timestamp = int(time.time())
-        timestamp_dt = datetime.utcfromtimestamp(int_timestamp).astimezone(
+        timestamp_dt = datetime.fromtimestamp(int_timestamp, tz=tz.tzutc()).astimezone(
             tz.gettz("US/Pacific")
         )
         timezone = tz.gettz("US/Pacific")


### PR DESCRIPTION
First attempt at this as discussed, not sure about this behaviour though. Any thoughts @jadchaar ?

```shell
(arrow) chris@ThinkPad:~/arrow$ python
Python 3.7.4 (default, Sep 19 2019, 11:01:37) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> arrow.get(1367900664)
<Arrow [2013-05-07T04:24:24+00:00]>
>>> arrow.get(1367900664).replace(tzinfo="US/Pacific")
<Arrow [2013-05-07T04:24:24-07:00]>
>>> from dateutil import tz
>>> time_zone = tz.gettz('US/Pacific')
>>> arrow.get(1367900664, tzinfo=time_zone)
<Arrow [2013-05-06T21:24:24-07:00]>
```