### PR TITLE
Improve parsing of local strings with punctuation

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -299,8 +299,7 @@ class DateTimeParser(object):
 
         starting_word_boundary = (
             r"(?<!\S\S)"  # Don't have two consecutive non-whitespace characters. This ensures that we allow cases like .11.25.2019 but not 1.11.25.2019 (for pattern MM.DD.YYYY)
-            r"(?<![^\,\.\;\:\?\!\"\'\`\[\]\{\}("
-            r")<>\s])"  # This is the list of punctuation that is ok before the pattern (i.e. "It can't not be these characters before the pattern")
+            r"(?<![^\,\.\;\:\?\!\"\'\`\[\]\{\}\(\)<>\s])"  # This is the list of punctuation that is ok before the pattern (i.e. "It can't not be these characters before the pattern")
             r"(\b|^)"  # The \b is to block cases like 1201912 but allow 201912 for pattern YYYYMM. The ^ was necessary to allow a negative number through i.e. before epoch numbers
         )
         ending_word_boundary = (

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -297,7 +297,7 @@ class DateTimeParser(object):
         # "1998-09-12," is permitted. For the full list of valid punctuation,
         # see the documentation.
 
-        starting_punctuation_bound = r"(?<!\S\S)(?<!\s[^,.;:?!\"'`\[\]{}(" \
+        starting_punctuation_bound = r"(?<!\S\S)(?<![^,.;:?!\"'`\[\]{}(" \
                                      r")<>\s])(\b|^)"
         ending_punctuation_bound = r"(?=[,.;:?!\"'`\[\]{}()<>]?(?!\S))"
         bounded_fmt_pattern = r"{}{}{}".format(starting_punctuation_bound,

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -218,6 +218,7 @@ class DateTimeParser(object):
         fmt_tokens, fmt_pattern_re = self._generate_pattern_re(fmt)
 
         match = fmt_pattern_re.search(datetime_string)
+
         if match is None:
             raise ParserMatchError(
                 "Failed to match '{}' when parsing '{}'".format(fmt, datetime_string)
@@ -292,12 +293,16 @@ class DateTimeParser(object):
         # and time string in a natural language sentence. Therefore, searching
         # for a string of the form YYYY-MM-DD in "blah 1998-09-12 blah" will
         # work properly.
-        # Reference: https://stackoverflow.com/q/14232931/3820660
-        starting_word_boundary = r"(?<![\S])"
-        ending_word_boundary = r"(?![\S])"
-        bounded_fmt_pattern = r"{}{}{}".format(
-            starting_word_boundary, final_fmt_pattern, ending_word_boundary
-        )
+        # Certain punctuation before or after the target pattern such as
+        # "1998-09-12," is permitted. For the full list of valid punctuation,
+        # see the documentation.
+
+        starting_punctuation_bound = r"(?<!\S\S)(?<!\s[^,.;:?!\"'`\[\]{}(" \
+                                     r")<>\s])(\b|^)"
+        ending_punctuation_bound = r"(?=[,.;:?!\"'`\[\]{}()<>]?(?!\S))"
+        bounded_fmt_pattern = r"{}{}{}".format(starting_punctuation_bound,
+                                               final_fmt_pattern,
+                                               ending_punctuation_bound)
 
         return tokens, re.compile(bounded_fmt_pattern, flags=re.IGNORECASE)
 

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -297,12 +297,13 @@ class DateTimeParser(object):
         # "1998-09-12," is permitted. For the full list of valid punctuation,
         # see the documentation.
 
-        starting_punctuation_bound = r"(?<!\S\S)(?<![^,.;:?!\"'`\[\]{}(" \
-                                     r")<>\s])(\b|^)"
+        starting_punctuation_bound = (
+            r"(?<!\S\S)(?<![^,.;:?!\"'`\[\]{}(" r")<>\s])(\b|^)"
+        )
         ending_punctuation_bound = r"(?=[,.;:?!\"'`\[\]{}()<>]?(?!\S))"
-        bounded_fmt_pattern = r"{}{}{}".format(starting_punctuation_bound,
-                                               final_fmt_pattern,
-                                               ending_punctuation_bound)
+        bounded_fmt_pattern = r"{}{}{}".format(
+            starting_punctuation_bound, final_fmt_pattern, ending_punctuation_bound
+        )
 
         return tokens, re.compile(bounded_fmt_pattern, flags=re.IGNORECASE)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -431,13 +431,18 @@ You can also escape regular expressions by enclosing them within square brackets
 Punctuation
 ~~~~~~~~~~~
 
-You're date formats can be precede and/or be preceded by one character of
-punctuation from the list: :code:``, . ; : ? ! " ' \` [ ] { } ( ) < >``
+Date formats may be fenced on either side by one punctuation character from the following list: :literal:`, . ; : ? ! " \` ' [ ] { } ( ) < >`
 
 .. code-block:: python
 
     >>> arrow.get("Tomorrow (2019-10-31) is Halloween!", "YYYY-MM-DD")
     <Arrow [2019-10-31T00:00:00+00:00]>
+
+    >>> arrow.get("Halloween is on 2019.10.31.", "YYYY.MM.DD")
+    <Arrow [2019-10-31T00:00:00+00:00]>
+
+    >>> arrow.get("It's Halloween tomorrow (2019-10-31)!", "YYYY-MM-DD")
+    # Raises exception because there are multiple punctuation marks following the date
 
 API Guide
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -212,6 +212,7 @@ Support for a growing number of locales (see ``locales.py`` for supported langua
 
 .. code-block:: python
 
+
     >>> future = arrow.utcnow().shift(hours=1)
     >>> future.humanize(a, locale='ru')
     'через 2 час(а,ов)'
@@ -426,6 +427,17 @@ You can also escape regular expressions by enclosing them within square brackets
 
     >>> arrow.get("Mon Sep 08   16:41:45   2014", fmt)
     <Arrow [2014-09-08T16:41:45+00:00]>
+
+Punctuation
+~~~~~~~~~~~
+
+You're date formats can be precede and/or be preceded by one character of
+punctuation from the list: :code:`, . ; : ? ! " ' ` [ ] { } ( ) < >`
+
+.. code-block:: python
+
+    >>> arrow.get("Tomorrow (2019-10-31) is Halloween!", "YYYY-MM-DD")
+    <Arrow [2019-10-31T00:00:00+00:00]>
 
 API Guide
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -432,7 +432,7 @@ Punctuation
 ~~~~~~~~~~~
 
 You're date formats can be precede and/or be preceded by one character of
-punctuation from the list: :code:`, . ; : ? ! " ' ` [ ] { } ( ) < >`
+punctuation from the list: :code:``, . ; : ? ! " ' \` [ ] { } ( ) < >``
 
 .. code-block:: python
 

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -323,6 +323,14 @@ class GetTests(Chai):
             result._datetime, datetime(2010, 1, 1, 0, 0, 0, 0, tzinfo=tz.tzutc())
         )
 
+        # regression test for issue #701
+        result = self.factory.get(
+            "Montag, 9. September 2019, 16:15-20:00", "dddd, D. MMMM YYYY", locale="de"
+        )
+        self.assertEqual(
+            result._datetime, datetime(2019, 9, 9, 0, 0, 0, 0, tzinfo=tz.tzutc())
+        )
+
     def test_locale_kwarg_only(self):
         res = self.factory.get(locale="ja")
         self.assertEqual(res.tzinfo, tz.tzutc())

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -530,11 +530,15 @@ class DateTimeParserParseTests(Chai):
             datetime(2016, 5, 16, 4, 5, 6, 789120),
         )
 
+    # regression test for issue #701
+    # tests cases of a partial match surrounded by punctuation
+    # for the list of valid punctuation, see documentation
+    def test_parse_with_punctuation_fences(self):
         self.assertEqual(
             self.parser.parse(
-                "Meet me at my house on the my birthday (2019-24-11)", "YYYY-DD-MM"
+                "Meet me at my house on Halloween (2019-31-10)", "YYYY-DD-MM"
             ),
-            datetime(2019, 11, 24),
+            datetime(2019, 10, 31),
         )
 
         self.assertEqual(
@@ -548,6 +552,15 @@ class DateTimeParserParseTests(Chai):
             self.parser.parse("A date is 11.11.2011.", "DD.MM.YYYY"),
             datetime(2011, 11, 11),
         )
+
+        with self.assertRaises(ParserMatchError):
+            self.parser.parse("11.11.2011.1 is not a valid date.", "DD.MM.YYYY")
+
+        with self.assertRaises(ParserMatchError):
+            self.parser.parse(
+                "This date has too many punctuation marks following it (11.11.2011).",
+                "DD.MM.YYYY",
+            )
 
     def test_parse_with_leading_and_trailing_whitespace(self):
         self.assertEqual(self.parser.parse("      2016", "YYYY"), datetime(2016, 1, 1))

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -472,7 +472,10 @@ class DateTimeParserParseTests(Chai):
 
     def test_parse_with_extra_words_at_start_and_end_valid(self):
         # Spaces surrounding the parsable date are ok because we
-        # allow the parsing of natural language input
+        # allow the parsing of natural language input. Additionally, a single
+        # character of specific punctuation before or after the date is okay.
+        # See docs for full list of valid punctuation.
+
         self.assertEqual(
             self.parser.parse("blah 2016 blah", "YYYY"), datetime(2016, 1, 1)
         )
@@ -525,6 +528,30 @@ class DateTimeParserParseTests(Chai):
                 "YYYY-MM-DD hh:mm:ss.S",
             ),
             datetime(2016, 5, 16, 4, 5, 6, 789120),
+        )
+
+        self.assertEqual(
+            self.parser.parse(
+                "Meet me at my house on the my birthday (2019-24-11)",
+                "YYYY-DD-MM"
+            ),
+            datetime(2019, 11, 24)
+        )
+
+        self.assertEqual(
+            self.parser.parse(
+                "Monday, 9. September 2019, 16:15-20:00",
+                "dddd, D. MMMM YYYY"
+            ),
+            datetime(2019, 9, 9)
+        )
+
+        self.assertEqual(
+            self.parser.parse(
+                "A date is 11.11.2011.",
+                "DD.MM.YYYY"
+            ),
+            datetime(2011, 11, 11)
         )
 
     def test_parse_with_leading_and_trailing_whitespace(self):

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -532,26 +532,21 @@ class DateTimeParserParseTests(Chai):
 
         self.assertEqual(
             self.parser.parse(
-                "Meet me at my house on the my birthday (2019-24-11)",
-                "YYYY-DD-MM"
+                "Meet me at my house on the my birthday (2019-24-11)", "YYYY-DD-MM"
             ),
-            datetime(2019, 11, 24)
+            datetime(2019, 11, 24),
         )
 
         self.assertEqual(
             self.parser.parse(
-                "Monday, 9. September 2019, 16:15-20:00",
-                "dddd, D. MMMM YYYY"
+                "Monday, 9. September 2019, 16:15-20:00", "dddd, D. MMMM YYYY"
             ),
-            datetime(2019, 9, 9)
+            datetime(2019, 9, 9),
         )
 
         self.assertEqual(
-            self.parser.parse(
-                "A date is 11.11.2011.",
-                "DD.MM.YYYY"
-            ),
-            datetime(2011, 11, 11)
+            self.parser.parse("A date is 11.11.2011.", "DD.MM.YYYY"),
+            datetime(2011, 11, 11),
         )
 
     def test_parse_with_leading_and_trailing_whitespace(self):


### PR DESCRIPTION
This should fix #701. I decided to allow the punctuation: `` , . ; : ? ! " ' ` [ ] { } ( ) < > ``.