### PR TITLE
Added PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: "🐞Bug Report"
+name: "🐞 Bug Report"
 about: Find a bug? Create a report to help us improve.
 title: ''
 labels: 'bug'

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: "🐞Bug Report"
+about: Find a bug? Create a report to help us improve.
+title: ''
+labels: 'bug'
+assignees: ''
+---
+
+<!--
+Thanks for taking the time to submit this bug report.
+
+Please provide us with a detailed description of the
+bug and a bit of information about your system.
+-->
+
+## Issue Description
+
+<!--
+Replace with a description of the bug.
+
+Be sure to include details such as the expected
+and actual outcomes. Happy bug reporting 🐞!
+-->
+
+## System Info
+
+- 🖥 **OS name and version**: <!-- Replace with OS name and version (e.g. macOS 10.15.1) -->
+- 🐍 **Python version**: <!-- Replace with Python version (e.g. Python 3.7.3). -->
+- 🏹 **Arrow version**: <!-- Replace with Arrow version. You can run arrow.__version__ to find out! -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,17 @@
+---
+name: "📚Documentation"
+about: Find errors or problems in the docs (https://arrow.readthedocs.io)?
+title: ''
+labels: 'documentation'
+assignees: ''
+---
+
+<!--
+Thanks for taking the time to submit documentation feedback.
+
+Please provide us with a detailed description of the documentation issue.
+-->
+
+## Issue Description
+
+<!-- Replace with a description of the documentation issue. -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,5 +1,5 @@
 ---
-name: "📚Documentation"
+name: "📚 Documentation"
 about: Find errors or problems in the docs (https://arrow.readthedocs.io)?
 title: ''
 labels: 'documentation'

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: "💡Feature Request"
+about: Have an idea for a new feature or improvement?
+title: ''
+labels: 'enhancement'
+assignees: ''
+---
+
+<!--
+Thanks for taking the time to submit this feature request.
+
+Please provide us with a detailed description of the
+potential improvement. Happy feature requesting 💡!
+-->
+
+## Feature Request
+
+<!-- Replace with a description of the potential improvement. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: "💡Feature Request"
+name: "💡 Feature Request"
 about: Have an idea for a new feature or improvement?
 title: ''
 labels: 'enhancement'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,10 @@
 Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:
 
 <!-- Check boxes by placing an x in the brackets: [x] -->
-- [ ] 🧪Added **tests** for changed code.
-- [ ] 🛠️All tests **pass** when run locally (run `tox` or `make test` to find out!).
-- [ ] 📚Updated **documentation** for changed code.
-- [ ] ⏩Code is **up-to-date** with the `master` branch.
+- [ ] 🧪 Added **tests** for changed code.
+- [ ] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
+- [ ] 📚 Updated **documentation** for changed code.
+- [ ] ⏩ Code is **up-to-date** with the `master` branch.
 
 If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Pull Request Checklist
+
+Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:
+
+<!-- Check boxes by placing an x in the brackets: [x] -->
+- [ ] 🧪Added **tests** for changed code.
+- [ ] 🛠️All tests **pass** when run locally (run `tox` or `make test` to find out!).
+- [ ] 📚Updated **documentation** for changed code.
+- [ ] ⏩Code is **up-to-date** with the `master` branch.
+
+If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!
+
+## Description of Changes
+
+<!--
+Replace with description of code changes.
+
+If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/crsmithdev/arrow/issues/703).
+
+For example, doing the following will automatically close issue #703 when this PR is merged:
+
+Closes: #703
+-->


### PR DESCRIPTION
I got inspiration from https://github.com/psf/requests/issues/new/choose to add PR and issue templates. This will ease the process of triaging bugs and will improve PR and issue quality.

Will allow us to get more details about bugs and PRs up front rather than probing in extra follow ups.

We may have to talk to Chris about enabling the issue templates through settings, but I think they should work automatically since the folder and PR template naming is special.