### PR TITLE
Allow x token to be used in formatting

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -16,7 +16,7 @@ class DateTimeFormatter(object):
     # emulated in Python's re library, see https://stackoverflow.com/a/13577411/2701578
     # TODO: test against full timezone DB
     _FORMAT_RE = re.compile(
-        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|x)"
+        r"(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|x)"
     )
 
     def __init__(self, locale="en_us"):

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -100,10 +100,8 @@ class DateTimeFormatter(object):
         if token == "X":
             microsecond = str(int(dt.microsecond))
             return str(calendar.timegm(dt.utctimetuple())) + '.' + microsecond
-
         if token == "x":
             microsecond = str(int(dt.microsecond))
-
             return str(calendar.timegm(dt.utctimetuple())) + microsecond.rstrip('0')
 
         if token == "ZZZ":

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -16,7 +16,7 @@ class DateTimeFormatter(object):
     # emulated in Python's re library, see https://stackoverflow.com/a/13577411/2701578
     # TODO: test against full timezone DB
     _FORMAT_RE = re.compile(
-        r"(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|x)"
+        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X)"
     )
 
     def __init__(self, locale="en_us"):

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -99,10 +99,10 @@ class DateTimeFormatter(object):
 
         if token == "X":
             microsecond = str(int(dt.microsecond))
-            return str(calendar.timegm(dt.utctimetuple())) + '.' + microsecond
+            return str(calendar.timegm(dt.utctimetuple())) + "." + microsecond
         if token == "x":
             microsecond = str(int(dt.microsecond))
-            return str(calendar.timegm(dt.utctimetuple())) + microsecond.rstrip('0')
+            return str(calendar.timegm(dt.utctimetuple())) + microsecond.rstrip("0")
 
         if token == "ZZZ":
             return dt.tzname()

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -10,9 +10,13 @@ from arrow import locales, util
 
 
 class DateTimeFormatter(object):
+
+    # This pattern matches characters enclosed in square brackes are matched as
+    # an atomic group. For more info on atomic groups and how to they are
+    # emulated in Python's re library, see https://stackoverflow.com/a/13577411/2701578
     # TODO: test against full timezone DB
     _FORMAT_RE = re.compile(
-        r"(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X)"
+        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|x)"
     )
 
     def __init__(self, locale="en_us"):
@@ -24,6 +28,9 @@ class DateTimeFormatter(object):
         return cls._FORMAT_RE.sub(lambda m: cls._format_token(dt, m.group(0)), fmt)
 
     def _format_token(self, dt, token):
+
+        if token and token.startswith("[") and token.endswith("]"):
+            return token[1:-1]
 
         if token == "YYYY":
             return self.locale.year_full(dt.year)
@@ -91,7 +98,13 @@ class DateTimeFormatter(object):
             return str(int(dt.microsecond / 100000))
 
         if token == "X":
-            return str(calendar.timegm(dt.utctimetuple()))
+            microsecond = str(int(dt.microsecond))
+            return str(calendar.timegm(dt.utctimetuple())) + '.' + microsecond
+
+        if token == "x":
+            microsecond = str(int(dt.microsecond))
+
+            return str(calendar.timegm(dt.utctimetuple())) + microsecond.rstrip('0')
 
         if token == "ZZZ":
             return dt.tzname()

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -104,11 +104,12 @@ class DateTimeFormatterFormatTokenTests(Chai):
         self.assertEqual(self.formatter._format_token(dt, "S"), "0")
 
     def test_timestamp(self):
-
-        timestamp = time.time()
-        dt = datetime.utcfromtimestamp(timestamp)
-        self.assertEqual(self.formatter._format_token(dt, "X"), str(int(timestamp)))
-
+        dt = datetime(2019, 12, 3, 0, 20, 1, 728968)
+        self.assertEqual(self.formatter._format_token(dt, "X"), "1575332401.728968")
+        
+        dt = datetime(2019, 12, 3, 0, 20, 1, 728968)
+        self.assertEqual(self.formatter._format_token(dt, "X"), "1575332401728968")
+        
     def test_timezone(self):
 
         dt = datetime.utcnow().replace(tzinfo=dateutil_tz.gettz("US/Pacific"))

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -104,9 +104,10 @@ class DateTimeFormatterFormatTokenTests(Chai):
         self.assertEqual(self.formatter._format_token(dt, "S"), "0")
 
     def test_timestamp(self):
+
         dt = datetime(2019, 12, 3, 0, 20, 1, 728968)
         self.assertEqual(self.formatter._format_token(dt, "X"), "1575332401.728968")
-        
+
         dt = datetime(2019, 12, 3, 0, 20, 1, 728968)
         self.assertEqual(self.formatter._format_token(dt, "x"), "1575332401728968")
         

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -108,7 +108,7 @@ class DateTimeFormatterFormatTokenTests(Chai):
         self.assertEqual(self.formatter._format_token(dt, "X"), "1575332401.728968")
         
         dt = datetime(2019, 12, 3, 0, 20, 1, 728968)
-        self.assertEqual(self.formatter._format_token(dt, "X"), "1575332401728968")
+        self.assertEqual(self.formatter._format_token(dt, "x"), "1575332401728968")
         
     def test_timezone(self):
 

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import time
 from datetime import datetime
 
 import pytz

--- a/tests/formatter_tests.py
+++ b/tests/formatter_tests.py
@@ -110,7 +110,7 @@ class DateTimeFormatterFormatTokenTests(Chai):
 
         dt = datetime(2019, 12, 3, 0, 20, 1, 728968)
         self.assertEqual(self.formatter._format_token(dt, "x"), "1575332401728968")
-        
+
     def test_timezone(self):
 
         dt = datetime.utcnow().replace(tzinfo=dateutil_tz.gettz("US/Pacific"))


### PR DESCRIPTION
for "X" token now we can show timestamp in float number
for "x" token eliminated the zeros in the end

## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

<!--
Replace with description of code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/crsmithdev/arrow/issues/703).

For example, doing the following will automatically close issue #703 when this PR is merged:

Closes: #703
-->
