### PR TITLE
Revert support for negative timestamps on Windows

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -162,7 +162,7 @@ class Arrow(object):
                 "The provided timestamp '{}' is invalid.".format(timestamp)
             )
 
-        dt = util.safe_fromtimestamp(float(timestamp), tzinfo)
+        dt = datetime.fromtimestamp(float(timestamp), tzinfo)
 
         return cls(
             dt.year,
@@ -188,7 +188,7 @@ class Arrow(object):
                 "The provided timestamp '{}' is invalid.".format(timestamp)
             )
 
-        dt = util.safe_utcfromtimestamp(float(timestamp))
+        dt = datetime.utcfromtimestamp(float(timestamp))
 
         return cls(
             dt.year,

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from dateutil import tz
 
-from arrow import locales, util
+from arrow import locales
 from arrow.constants import MAX_TIMESTAMP, MAX_TIMESTAMP_MS, MAX_TIMESTAMP_US
 
 try:
@@ -383,7 +383,7 @@ class DateTimeParser(object):
         timestamp = parts.get("timestamp")
 
         if timestamp is not None:
-            return util.safe_fromtimestamp(timestamp, tz=tz.tzutc())
+            return datetime.fromtimestamp(timestamp, tz=tz.tzutc())
 
         expanded_timestamp = parts.get("expanded_timestamp")
 
@@ -401,7 +401,7 @@ class DateTimeParser(object):
                         )
                     )
 
-            return util.safe_fromtimestamp(expanded_timestamp, tz=tz.tzutc())
+            return datetime.fromtimestamp(expanded_timestamp, tz=tz.tzutc())
 
         day_of_year = parts.get("day_of_year")
 

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -2,11 +2,6 @@
 from __future__ import absolute_import
 
 import datetime
-import math
-import time
-from os import name as os_name
-
-import dateutil
 
 
 def total_seconds(td):  # pragma: no cover
@@ -26,44 +21,6 @@ def is_timestamp(value):
         return True
     except ValueError:
         return False
-
-
-def windows_datetime_from_timestamp(timestamp, tz=None):
-    """Computes datetime from timestamp. Supports negative timestamps on Windows platform."""
-    sec_frac, sec = math.modf(timestamp)
-    dt = datetime.datetime(1970, 1, 1, tzinfo=dateutil.tz.tzutc()) + datetime.timedelta(
-        seconds=sec, microseconds=sec_frac * 1000000
-    )
-    if tz is None:
-        tz = dateutil.tz.tzlocal()
-
-    if tz == dateutil.tz.tzlocal():
-        # because datetime.astimezone does not work on Windows for tzlocal() and dates before the 1970-01-01
-        # take timestamp from appropriate time of the year, because of daylight saving time changes
-        ts = time.mktime(dt.replace(year=1970).timetuple())
-        dt += datetime.datetime.fromtimestamp(ts) - datetime.datetime.utcfromtimestamp(
-            ts
-        )
-        dt = dt.replace(tzinfo=dateutil.tz.tzlocal())
-    else:
-        dt = dt.astimezone(tz)
-    return dt
-
-
-def safe_utcfromtimestamp(timestamp):
-    """ datetime.utcfromtimestamp alternative which supports negative timestamps on Windows platform."""
-    if os_name == "nt" and timestamp < 0:
-        return windows_datetime_from_timestamp(timestamp, dateutil.tz.tzutc())
-    else:
-        return datetime.datetime.utcfromtimestamp(timestamp)
-
-
-def safe_fromtimestamp(timestamp, tz=None):
-    """ datetime.fromtimestamp alternative which supports negative timestamps on Windows platform."""
-    if os_name == "nt" and timestamp < 0:
-        return windows_datetime_from_timestamp(timestamp, tz)
-    else:
-        return datetime.datetime.fromtimestamp(timestamp, tz)
 
 
 # Credit to https://stackoverflow.com/a/1700069
@@ -100,12 +57,4 @@ except NameError:  # pragma: no cover
         return isinstance(s, str)
 
 
-__all__ = [
-    "total_seconds",
-    "is_timestamp",
-    "isstr",
-    "iso_to_gregorian",
-    "windows_datetime_from_timestamp",
-    "safe_utcfromtimestamp",
-    "safe_fromtimestamp",
-]
+__all__ = ["total_seconds", "is_timestamp", "isstr", "iso_to_gregorian"]

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 import time
-from datetime import datetime
 
 from chai import Chai
-from dateutil import tz
-from mock import patch
 
 from arrow import util
 
@@ -36,63 +33,3 @@ class UtilTests(Chai):
 
         with self.assertRaises(ValueError):
             util.iso_to_gregorian(2013, 8, 0)
-
-    def test_windows_datetime_from_timestamp(self):
-        timestamp = 1572204340.6460679
-        result = util.windows_datetime_from_timestamp(timestamp)
-        expected = datetime.fromtimestamp(timestamp).replace(tzinfo=tz.tzlocal())
-        self.assertEqual(result, expected)
-
-    def test_windows_datetime_from_timestamp_utc(self):
-        timestamp = 1572204340.6460679
-        result = util.windows_datetime_from_timestamp(timestamp, tz.tzutc())
-        expected = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
-        self.assertEqual(result, expected)
-
-    def test_safe_utcfromtimestamp(self):
-        timestamp = 1572204340.6460679
-        result = util.safe_utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
-        expected = datetime.utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
-        self.assertEqual(result, expected)
-
-    def test_safe_fromtimestamp_default_tz(self):
-        timestamp = 1572204340.6460679
-        result = util.safe_fromtimestamp(timestamp).replace(tzinfo=tz.tzlocal())
-        expected = datetime.fromtimestamp(timestamp).replace(tzinfo=tz.tzlocal())
-        self.assertEqual(result, expected)
-
-    def test_safe_fromtimestamp_paris_tz(self):
-        timestamp = 1572204340.6460679
-        result = util.safe_fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
-        expected = datetime.fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
-        self.assertEqual(result, expected)
-
-    def test_safe_utcfromtimestamp_negative(self):
-        timestamp = -1572204340.6460679
-        result = util.safe_utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
-        expected = datetime(1920, 3, 7, 4, 34, 19, 353932, tzinfo=tz.tzutc())
-        self.assertEqual(result, expected)
-
-    def test_safe_fromtimestamp_negative(self):
-        timestamp = -1572204340.6460679
-        result = util.safe_fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
-        expected = datetime(
-            1920, 3, 7, 5, 34, 19, 353932, tzinfo=tz.gettz("Europe/Paris")
-        )
-        self.assertEqual(result, expected)
-
-    @patch.object(util, "os_name", "nt")
-    def test_safe_utcfromtimestamp_negative_nt(self):
-        timestamp = -1572204340.6460679
-        result = util.safe_utcfromtimestamp(timestamp).replace(tzinfo=tz.tzutc())
-        expected = datetime(1920, 3, 7, 4, 34, 19, 353932, tzinfo=tz.tzutc())
-        self.assertEqual(result, expected)
-
-    @patch.object(util, "os_name", "nt")
-    def test_safe_fromtimestamp_negative_nt(self):
-        timestamp = -1572204340.6460679
-        result = util.safe_fromtimestamp(timestamp, tz.gettz("Europe/Paris"))
-        expected = datetime(
-            1920, 3, 7, 5, 34, 19, 353932, tzinfo=tz.gettz("Europe/Paris")
-        )
-        self.assertEqual(result, expected)


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [ ] 🧪 Added **tests** for changed code.
- [ ] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [ ] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Reverts #700 entirely due to https://github.com/crsmithdev/arrow/blob/master/tests/util_tests.py#L58 causing intermittent test (and hence build) failures. There is also some debate whether the feature is actually returning correct answers due to DST causing problems.

ref #675 
/cc @kkoziara 