### PR TITLE
Add support for parsing and formatting ISO 8601 week dates

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -14,7 +14,7 @@ class DateTimeFormatter(object):
     # This pattern matches characters enclosed in square brackets are matched as
     # an atomic group. For more info on atomic groups and how to they are
     # emulated in Python's re library, see https://stackoverflow.com/a/13577411/2701578
-    # TODO: test against full timezone DB
+
     _FORMAT_RE = re.compile(
         r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|W)"
     )

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -11,12 +11,12 @@ from arrow import locales, util
 
 class DateTimeFormatter(object):
 
-    # This pattern matches characters enclosed in square brackes are matched as
+    # This pattern matches characters enclosed in square brackets are matched as
     # an atomic group. For more info on atomic groups and how to they are
     # emulated in Python's re library, see https://stackoverflow.com/a/13577411/2701578
     # TODO: test against full timezone DB
     _FORMAT_RE = re.compile(
-        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X)"
+        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|W)"
     )
 
     def __init__(self, locale="en_us"):
@@ -116,3 +116,7 @@ class DateTimeFormatter(object):
 
         if token in ("a", "A"):
             return self.locale.meridian(dt.hour, token)
+
+        if token == "W":
+            year, week, day = dt.isocalendar()
+            return "{}-W{:02d}-{}".format(year, week, day)

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -50,7 +50,7 @@ class DateTimeParser(object):
     _TIMESTAMP_RE = re.compile(r"^\-?\d+\.?\d+$")
     _TIMESTAMP_EXPANDED_RE = re.compile(r"^\-?\d+$")
     _TIME_RE = re.compile(r"^(\d{2})(?:\:?(\d{2}))?(?:\:?(\d{2}))?(?:([\.\,])(\d+))?$")
-    _WEEK_DATE_RE = re.compile(r"^(\d{4})([\-])?W(\d{2})(?:([\-])?(\d))?$")
+    _WEEK_DATE_RE = re.compile(r"(\d{4})([\-])?W(\d{2})(?:([\-])?(\d))?")
 
     _BASE_INPUT_RE_MAP = {
         "YYYY": _FOUR_DIGIT_RE,

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -50,7 +50,7 @@ class DateTimeParser(object):
     _TIMESTAMP_RE = re.compile(r"^\-?\d+\.?\d+$")
     _TIMESTAMP_EXPANDED_RE = re.compile(r"^\-?\d+$")
     _TIME_RE = re.compile(r"^(\d{2})(?:\:?(\d{2}))?(?:\:?(\d{2}))?(?:([\.\,])(\d+))?$")
-    _WEEK_DATE_RE = re.compile(r"(\d{4})([\-])?W(\d{2})(?:([\-])?(\d))?")
+    _WEEK_DATE_RE = re.compile(r"(?P<year>\d{4})[\-]?W(?P<week>\d{2})[\-]?(?P<day>\d)?")
 
     _BASE_INPUT_RE_MAP = {
         "YYYY": _FOUR_DIGIT_RE,
@@ -233,7 +233,7 @@ class DateTimeParser(object):
             if token == "Do":
                 value = match.group("value")
             elif token == "W":
-                value = (match.group(3), match.group(5), match.group(7))
+                value = (match.group("year"), match.group("week"), match.group("day"))
             else:
                 value = match.group(token)
             self._parse_token(token, value, parts)
@@ -309,7 +309,7 @@ class DateTimeParser(object):
             r"(\b|^)"  # The \b is to block cases like 1201912 but allow 201912 for pattern YYYYMM. The ^ was necessary to allow a negative number through i.e. before epoch numbers
         )
         ending_word_boundary = (
-            r"(?=[\,\.\;\:\?\!\"\'\`\[\]\{\}\(\)\<\>]?"  # Positive lookahead stating that these punctuation marks can appear after the pattern at most 1 time
+            r"(?=[\,\.\;\:\?\!\"\'\`\[\]\{\}\(\)\<\>T]?"  # Positive lookahead stating that these punctuation marks can appear after the pattern at most 1 time
             r"(?!\S))"  # Don't allow any non-whitespace character after the punctuation
         )
         bounded_fmt_pattern = r"{}{}{}".format(
@@ -395,9 +395,9 @@ class DateTimeParser(object):
             # we can use strptime (%G, %V, %u) in python 3.6 but these tokens aren't available before that
             year, week = int(weekdate[0]), int(weekdate[1].lstrip("0"))
 
-            try:
+            if weekdate[2] is not None:
                 day = int(weekdate[2])
-            except TypeError:
+            else:
                 # day not given, default to 1
                 day = 1
 

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -8,6 +8,7 @@ from dateutil import tz
 
 from arrow import locales
 from arrow.constants import MAX_TIMESTAMP, MAX_TIMESTAMP_MS, MAX_TIMESTAMP_US
+from arrow.util import iso_to_gregorian
 
 try:
     from functools import lru_cache
@@ -31,7 +32,7 @@ class ParserMatchError(ParserError):
 class DateTimeParser(object):
 
     _FORMAT_RE = re.compile(
-        r"(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?d?d?d|HH?|hh?|mm?|ss?|S+|ZZ?Z?|a|A|x|X)"
+        r"(YYY?Y?|MM?M?M?|Do|DD?D?D?|d?d?d?d|HH?|hh?|mm?|ss?|S+|ZZ?Z?|a|A|x|X|W)"
     )
     _ESCAPE_RE = re.compile(r"\[[^\[\]]*\]")
 
@@ -49,6 +50,7 @@ class DateTimeParser(object):
     _TIMESTAMP_RE = re.compile(r"^\-?\d+\.?\d+$")
     _TIMESTAMP_EXPANDED_RE = re.compile(r"^\-?\d+$")
     _TIME_RE = re.compile(r"^(\d{2})(?:\:?(\d{2}))?(?:\:?(\d{2}))?(?:([\.\,])(\d+))?$")
+    _WEEK_DATE_RE = re.compile(r"^(\d{4})([\-])?W(\d{2})(?:([\-])?(\d))?$")
 
     _BASE_INPUT_RE_MAP = {
         "YYYY": _FOUR_DIGIT_RE,
@@ -73,6 +75,7 @@ class DateTimeParser(object):
         "ZZ": _TZ_ZZ_RE,
         "Z": _TZ_Z_RE,
         "S": _ONE_OR_MORE_DIGIT_RE,
+        "W": _WEEK_DATE_RE,
     }
 
     SEPARATORS = ["-", "/", "."]
@@ -147,6 +150,7 @@ class DateTimeParser(object):
             "YYYY/MM",
             "YYYY.MM",
             "YYYY",
+            "W",
         ]
 
         if has_time:
@@ -228,6 +232,8 @@ class DateTimeParser(object):
         for token in fmt_tokens:
             if token == "Do":
                 value = match.group("value")
+            elif token == "W":
+                value = (match.group(3), match.group(5), match.group(7))
             else:
                 value = match.group(token)
             self._parse_token(token, value, parts)
@@ -377,8 +383,28 @@ class DateTimeParser(object):
             elif value in (self.locale.meridians["pm"], self.locale.meridians["PM"]):
                 parts["am_pm"] = "pm"
 
+        elif token == "W":
+            parts["weekdate"] = value
+
     @staticmethod
     def _build_datetime(parts):
+
+        weekdate = parts.get("weekdate")
+
+        if weekdate is not None:
+            # we can use strptime (%G, %V, %u) in python 3.6 but these tokens aren't available before that
+            year, week = int(weekdate[0]), int(weekdate[1].lstrip("0"))
+
+            try:
+                day = int(weekdate[2])
+            except TypeError:
+                # day not given, default to 1
+                day = 1
+
+            dt = iso_to_gregorian(year, week, day)
+            parts["year"] = dt.year
+            parts["month"] = dt.month
+            parts["day"] = dt.day
 
         timestamp = parts.get("timestamp")
 

--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -309,7 +309,7 @@ class DateTimeParser(object):
             r"(\b|^)"  # The \b is to block cases like 1201912 but allow 201912 for pattern YYYYMM. The ^ was necessary to allow a negative number through i.e. before epoch numbers
         )
         ending_word_boundary = (
-            r"(?=[\,\.\;\:\?\!\"\'\`\[\]\{\}\(\)\<\>T]?"  # Positive lookahead stating that these punctuation marks can appear after the pattern at most 1 time
+            r"(?=[\,\.\;\:\?\!\"\'\`\[\]\{\}\(\)\<\>]?"  # Positive lookahead stating that these punctuation marks can appear after the pattern at most 1 time
             r"(?!\S))"  # Don't allow any non-whitespace character after the punctuation
         )
         bounded_fmt_pattern = r"{}{}{}".format(
@@ -393,7 +393,7 @@ class DateTimeParser(object):
 
         if weekdate is not None:
             # we can use strptime (%G, %V, %u) in python 3.6 but these tokens aren't available before that
-            year, week = int(weekdate[0]), int(weekdate[1].lstrip("0"))
+            year, week = int(weekdate[0]), int(weekdate[1])
 
             if weekdate[2] is not None:
                 day = int(weekdate[2])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -332,7 +332,7 @@ Then get and use a factory for it:
 Supported Tokens
 ~~~~~~~~~~~~~~~~
 
-Use the following tokens in parsing and formatting.  Note that they're not the same as the tokens for `strptime(3) <https://www.gnu.org/software/libc/manual/html_node/Low_002dLevel-Time-String-Parsing.html#index-strptime>`_:
+Use the following tokens for parsing and formatting. Note that they are **not** the same as the tokens for `strptime <https://linux.die.net/man/3/strptime>`_:
 
 +--------------------------------+--------------+-------------------------------------------+
 |                                |Token         |Output                                     |
@@ -364,6 +364,8 @@ Use the following tokens in parsing and formatting.  Note that they're not the s
 |                                |ddd           |Mon, Tue, Wed ... [#t2]_                   |
 +--------------------------------+--------------+-------------------------------------------+
 |                                |d             |1, 2, 3 ... 6, 7                           |
++--------------------------------+--------------+-------------------------------------------+
+|**ISO week date**               |W             |2011-W05-4, 2019-W17                       |
 +--------------------------------+--------------+-------------------------------------------+
 |**Hour**                        |HH            |00, 01, 02 ... 23, 24                      |
 +--------------------------------+--------------+-------------------------------------------+

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -141,6 +141,14 @@ class TestDateTimeFormatterFormatToken:
         assert self.formatter._format_token(dt, "a") == "pm"
         assert self.formatter._format_token(dt, "A") == "PM"
 
+    def test_week(self):
+        dt = datetime(2017, 5, 19)
+        assert self.formatter._format_token(dt, "W") == "2017-W20-5"
+
+        # make sure week is zero padded when needed
+        dt_early = datetime(2011, 1, 20)
+        assert self.formatter._format_token(dt_early, "W") == "2011-W03-4"
+
     def test_nonsense(self):
         dt = datetime(2012, 1, 1, 11)
         assert self.formatter._format_token(dt, None) is None
@@ -193,5 +201,5 @@ class TestDateTimeFormatterFormatToken:
             == "Dec 31, 2017 |^${}().*+?<>-& 2:00 AM"
         )
 
-        # Escaping is atomic: brackets inside brackets are treated litterally
+        # Escaping is atomic: brackets inside brackets are treated literally
         assert self.formatter.format(datetime(1, 1, 1), "[[[ ]]") == "[[ ]"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -621,6 +621,29 @@ class TestDateTimeParserParse:
         with pytest.raises(ParserError):
             self.parser.parse("2019-12-31T24:00:00.999999", "YYYY-MM-DDTHH:mm:ss.S")
 
+    def test_parse_W(self):
+        good_full_formats = ["2011-W05-4", "2011W054"]
+        good_part_formats = ["2011-W05", "2011W05"]
+
+        for fmt in good_full_formats:
+            assert self.parser.parse(fmt, "W") == datetime(2011, 2, 3, 0, 0, 0, 0)
+
+        for fmt in good_part_formats:
+            assert self.parser.parse(fmt, "W") == datetime(2011, 1, 31, 0, 0, 0, 0)
+
+        bad_formats = [
+            "201W22",
+            "1995-W1-4",
+            "2001-W34-90",
+            "2001--W34",
+            "2011-W03--3",
+            "thstrdjtrsrd676776r65",
+        ]
+
+        for fmt in bad_formats:
+            with pytest.raises(ParserError):
+                self.parser.parse(fmt, "W")
+
 
 class TestDateTimeParserRegex:
     @classmethod
@@ -963,6 +986,10 @@ class TestDateTimeParserISO:
         assert self.parser.parse_iso("2013-02-03 04:05:06.78912Z") == datetime(
             2013, 2, 3, 4, 5, 6, 789120, tzinfo=tz.tzutc()
         )
+
+    def test_W(self):
+
+        assert self.parser.parse_iso("2011-W05-4") == datetime(2011, 2, 3, 0, 0, 0, 0)
 
     def test_invalid_Z(self):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -624,12 +624,16 @@ class TestDateTimeParserParse:
     def test_parse_W(self):
         good_full_formats = ["2011-W05-4", "2011W054"]
         good_part_formats = ["2011-W05", "2011W05"]
+        good_formats_with_time = ["2011-W05-4T14:17:01", "2011W054T14:17:01", "2011-W05-4T141701", "2011W054T141701"]
 
         for fmt in good_full_formats:
-            assert self.parser.parse(fmt, "W") == datetime(2011, 2, 3, 0, 0, 0, 0)
+            assert self.parser.parse(fmt, "W") == datetime(2011, 2, 3)
 
         for fmt in good_part_formats:
-            assert self.parser.parse(fmt, "W") == datetime(2011, 1, 31, 0, 0, 0, 0)
+            assert self.parser.parse(fmt, "W") == datetime(2011, 1, 31)
+
+        for fmt in good_formats_with_time:
+            assert self.parser.parse(fmt, "W") == datetime(2011, 1, 31, 14, 17, 1)
 
         bad_formats = [
             "201W22",
@@ -638,6 +642,7 @@ class TestDateTimeParserParse:
             "2001--W34",
             "2011-W03--3",
             "thstrdjtrsrd676776r65",
+            "2002-W66-1T14:17:01"
         ]
 
         for fmt in bad_formats:
@@ -989,7 +994,13 @@ class TestDateTimeParserISO:
 
     def test_W(self):
 
-        assert self.parser.parse_iso("2011-W05-4") == datetime(2011, 2, 3, 0, 0, 0, 0)
+        assert self.parser.parse_iso("2011-W05-4") == datetime(2011, 2, 3)
+
+        assert self.parser.parse_iso("2011-W05-4T14:17:01") == datetime(2011, 2, 3, 14, 17, 1)
+
+        assert self.parser.parse_iso("2011W054") == datetime(2011, 2, 3)
+
+        assert self.parser.parse_iso("2011W054T141701") == datetime(2011, 2, 3, 14, 17, 1)
 
     def test_invalid_Z(self):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -622,18 +622,26 @@ class TestDateTimeParserParse:
             self.parser.parse("2019-12-31T24:00:00.999999", "YYYY-MM-DDTHH:mm:ss.S")
 
     def test_parse_W(self):
-        good_full_formats = ["2011-W05-4", "2011W054"]
-        good_part_formats = ["2011-W05", "2011W05"]
-        good_formats_with_time = ["2011-W05-4T14:17:01", "2011W054T14:17:01", "2011-W05-4T141701", "2011W054T141701"]
 
-        for fmt in good_full_formats:
-            assert self.parser.parse(fmt, "W") == datetime(2011, 2, 3)
-
-        for fmt in good_part_formats:
-            assert self.parser.parse(fmt, "W") == datetime(2011, 1, 31)
-
-        for fmt in good_formats_with_time:
-            assert self.parser.parse(fmt, "W") == datetime(2011, 1, 31, 14, 17, 1)
+        assert self.parser.parse("2011-W05-4", "W") == datetime(2011, 2, 3)
+        assert self.parser.parse("2011W054", "W") == datetime(2011, 2, 3)
+        assert self.parser.parse("2011-W05", "W") == datetime(2011, 1, 31)
+        assert self.parser.parse("2011W05", "W") == datetime(2011, 1, 31)
+        assert self.parser.parse("2011-W05-4T14:17:01", "WTHH:mm:ss") == datetime(
+            2011, 2, 3, 14, 17, 1
+        )
+        assert self.parser.parse("2011W054T14:17:01", "WTHH:mm:ss") == datetime(
+            2011, 2, 3, 14, 17, 1
+        )
+        assert self.parser.parse("2011-W05T14:17:01", "WTHH:mm:ss") == datetime(
+            2011, 1, 31, 14, 17, 1
+        )
+        assert self.parser.parse("2011W05T141701", "WTHHmmss") == datetime(
+            2011, 1, 31, 14, 17, 1
+        )
+        assert self.parser.parse("2011W054T141701", "WTHHmmss") == datetime(
+            2011, 2, 3, 14, 17, 1
+        )
 
         bad_formats = [
             "201W22",
@@ -642,7 +650,8 @@ class TestDateTimeParserParse:
             "2001--W34",
             "2011-W03--3",
             "thstrdjtrsrd676776r65",
-            "2002-W66-1T14:17:01"
+            "2002-W66-1T14:17:01",
+            "2002-W23-03T14:17:01",
         ]
 
         for fmt in bad_formats:
@@ -996,11 +1005,15 @@ class TestDateTimeParserISO:
 
         assert self.parser.parse_iso("2011-W05-4") == datetime(2011, 2, 3)
 
-        assert self.parser.parse_iso("2011-W05-4T14:17:01") == datetime(2011, 2, 3, 14, 17, 1)
+        assert self.parser.parse_iso("2011-W05-4T14:17:01") == datetime(
+            2011, 2, 3, 14, 17, 1
+        )
 
         assert self.parser.parse_iso("2011W054") == datetime(2011, 2, 3)
 
-        assert self.parser.parse_iso("2011W054T141701") == datetime(2011, 2, 3, 14, 17, 1)
+        assert self.parser.parse_iso("2011W054T141701") == datetime(
+            2011, 2, 3, 14, 17, 1
+        )
 
     def test_invalid_Z(self):
 


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

This adds support for ISO 8601 [week dates](https://en.wikipedia.org/wiki/ISO_week_date) via a new token `"W"`.

```shell
(arrow) chris@ThinkPad:~/arrow$ python
Python 3.7.4 (default, Sep 19 2019, 11:01:37) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> arrow.get("2013-W29-6", "W")
<Arrow [2013-07-20T00:00:00+00:00]>
>>> arrow.get("2013-W12", "W")
<Arrow [2013-03-18T00:00:00+00:00]>
>>> arrow.get("2013W296", "W")
<Arrow [2013-07-20T00:00:00+00:00]>
>>> arrow.get("2013W12", "W")
<Arrow [2013-03-18T00:00:00+00:00]>
>>> utc=arrow.utcnow()
>>> utc
<Arrow [2020-01-23T18:37:55.417624+00:00]>
>>> utc.format("W")
'2020-W04-4'
```

I still need to update the docs, let me know what you think @jadchaar.