### PR TITLE
Implement ambiguous and imaginary datetime handling (PEP 495)

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -358,7 +358,7 @@ class Arrow(object):
 
         while current <= end and i < limit:
             i += 1
-            yield current
+            yield dateutil_tz.resolve_imaginary(current)
 
             values = [getattr(current, f) for f in cls._ATTRS]
             current = cls(*values, tzinfo=tzinfo) + relativedelta(
@@ -696,6 +696,8 @@ class Arrow(object):
 
         current = self._datetime + relativedelta(**relative_kwargs)
 
+        current = dateutil_tz.resolve_imaginary(current)
+
         return self.fromdatetime(current)
 
     def to(self, tz):
@@ -848,7 +850,7 @@ class Arrow(object):
             >>> arrow.utcnow().ceil('hour')
             <Arrow [2013-05-09T03:59:59.999999+00:00]>
         """
-
+        # NOTE may cause weird behaviour with resolve imaginary
         return self.span(frame)[1]
 
     # string output and formatting.

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -64,7 +64,16 @@ class Arrow(object):
     _SECS_PER_YEAR = float(60 * 60 * 24 * 365.25)
 
     def __init__(
-        self, year, month, day, hour=0, minute=0, second=0, microsecond=0, tzinfo=None
+        self,
+        year,
+        month,
+        day,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
+        tzinfo=None,
+        fold=0,
     ):
         if tzinfo is None:
             tzinfo = dateutil_tz.tzutc()
@@ -80,7 +89,7 @@ class Arrow(object):
             tzinfo = parser.TzinfoParser.parse(tzinfo)
 
         self._datetime = datetime(
-            year, month, day, hour, minute, second, microsecond, tzinfo
+            year, month, day, hour, minute, second, microsecond, tzinfo, fold=fold
         )
 
     # factories: single object, both original and from datetime.
@@ -112,6 +121,7 @@ class Arrow(object):
             dt.second,
             dt.microsecond,
             dt.tzinfo,
+            dt.fold,
         )
 
     @classmethod
@@ -169,6 +179,7 @@ class Arrow(object):
             dt.second,
             dt.microsecond,
             dt.tzinfo,
+            dt.fold,
         )
 
     @classmethod
@@ -230,6 +241,7 @@ class Arrow(object):
             dt.second,
             dt.microsecond,
             tzinfo,
+            dt.fold,
         )
 
     @classmethod
@@ -276,6 +288,7 @@ class Arrow(object):
             dt.second,
             dt.microsecond,
             tzinfo,
+            dt.fold,
         )
 
     # factories: ranges and spans
@@ -728,6 +741,7 @@ class Arrow(object):
             dt.second,
             dt.microsecond,
             dt.tzinfo,
+            dt.fold,
         )
 
     @classmethod

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 
 import calendar
 import sys
+import warnings
 from datetime import datetime, timedelta
 from datetime import tzinfo as dt_tzinfo
 from math import trunc
@@ -18,7 +19,6 @@ from dateutil.relativedelta import relativedelta
 from dateutil.tz import enfold
 
 from arrow import formatter, locales, parser, util
-import warnings
 
 
 class Arrow(object):
@@ -92,15 +92,19 @@ class Arrow(object):
 
         self._fold = fold
 
-        self._datetime = enfold(datetime(
-            year, month, day, hour, minute, second, microsecond, tzinfo), fold=self._fold
+        self._datetime = enfold(
+            datetime(year, month, day, hour, minute, second, microsecond, tzinfo),
+            fold=self._fold,
         )
 
-        # TODO make easier to understand, use actual timezone name
         # warn user if dt is imaginary
         if not dateutil_tz.datetime_exists(self._datetime):
-            warnings.warn("{} does not exist in the current timezone - {}".format(self._datetime, tzinfo), util.ImaginaryDatetimeWarning)
-
+            warnings.warn(
+                "{} does not exist in the current timezone - {}".format(
+                    self._datetime, tzinfo
+                ),
+                util.ImaginaryDatetimeWarning,
+            )
 
     # factories: single object, both original and from datetime.
 
@@ -159,7 +163,7 @@ class Arrow(object):
             dt.second,
             dt.microsecond,
             dt.tzinfo,
-            dt.fold
+            dt.fold,
         )
 
     @classmethod
@@ -222,7 +226,7 @@ class Arrow(object):
             dt.second,
             dt.microsecond,
             dateutil_tz.tzutc(),
-            dt.fold
+            dt.fold,
         )
 
     @classmethod
@@ -396,9 +400,7 @@ class Arrow(object):
 
             # IDEA use shift here instead?
 
-            current = base + relativedelta(
-                **{frame_relative: relative_steps}
-            )
+            current = base + relativedelta(**{frame_relative: relative_steps})
 
             current = dateutil_tz.resolve_imaginary(current._datetime)
             current = cls.fromdatetime(current)
@@ -626,20 +628,18 @@ class Arrow(object):
 
         return self.timestamp + float(self.microsecond) / 1000000
 
-    # TODO step through with debugger
     @property
     def fold(self):
         # in python < 3.6 _datetime will be a _DatetimeWithFold if fold=1 and a datetime with no fold attribute
         # otherwise, so we need to define a _fold attribute to cover this case
-        return getattr(self._datetime, 'fold', self._fold)
+        return getattr(self._datetime, "fold", self._fold)
 
     @fold.setter
     def fold(self, val):
         if val not in {0, 1}:
-            raise ValueError('fold attribute must be either 0 or 1')
+            raise ValueError("fold attribute must be either 0 or 1")
         self._fold = val
         self._datetime = enfold(self._datetime, fold=val)
-
 
     # mutation and duplication.
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -387,23 +387,18 @@ class Arrow(object):
             # TODO solution works but code style could be improved
             values = [getattr(current, f) for f in cls._ATTRS]
 
-            # TODO avoid printing warning output
             with warnings.catch_warnings():
-                warnings.filterwarnings("error", category=util.ImaginaryDatetimeWarning)
+                warnings.filterwarnings(
+                    "ignore", category=util.ImaginaryDatetimeWarning
+                )
+                base = cls(*values, tzinfo=tzinfo)
 
-                try:
-                    base = cls(*values, tzinfo=tzinfo)
-                except util.ImaginaryDatetimeWarning:
-                    dt_base = datetime(*values, tzinfo=tzinfo)
-                    non_im_base = dateutil_tz.resolve_imaginary(dt_base)
-                    base = cls.fromdatetime(non_im_base)
+                # IDEA use shift here instead?
 
-            # IDEA use shift here instead?
+                current = base + relativedelta(**{frame_relative: relative_steps})
 
-            current = base + relativedelta(**{frame_relative: relative_steps})
-
-            current = dateutil_tz.resolve_imaginary(current._datetime)
-            current = cls.fromdatetime(current)
+                current = dateutil_tz.resolve_imaginary(current._datetime)
+                current = cls.fromdatetime(current)
 
     @classmethod
     def span_range(cls, frame, start, end, tz=None, limit=None, bounds="[)"):

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -900,7 +900,7 @@ class Arrow(object):
             >>> arrow.utcnow().ceil('hour')
             <Arrow [2013-05-09T03:59:59.999999+00:00]>
         """
-        # NOTE may cause weird behaviour with resolve imaginary
+
         return self.span(frame)[1]
 
     # string output and formatting.

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -90,14 +90,13 @@ class Arrow(object):
         elif util.isstr(tzinfo):
             tzinfo = parser.TzinfoParser.parse(tzinfo)
 
-        # TODO drop and use _datetime attr instead?
         self._fold = fold
 
         self._datetime = enfold(datetime(
             year, month, day, hour, minute, second, microsecond, tzinfo), fold=self._fold
         )
 
-        # TODO make easier to understand
+        # TODO make easier to understand, use actual timezone name
         # warn user if dt is imaginary
         if not dateutil_tz.datetime_exists(self._datetime):
             warnings.warn("{} does not exist in current timezone".format(self._datetime), util.ImaginaryDatetimeWarning)
@@ -614,19 +613,17 @@ class Arrow(object):
     # TODO step through with debugger
     @property
     def fold(self):
+        # in python < 3.6 _datetime will be a _DatetimeWithFold if fold=1 and a datetime with no fold attribute
+        # otherwise, so we need to define a _fold attribute to cover this case
         return getattr(self._datetime, 'fold', self._fold)
 
     @fold.setter
     def fold(self, val):
-        if getattr(self._datetime, 'fold', None) is None:
-            # NOTE as currently designed there will always be a fold attr
-            if val not in {0, 1}:
-                raise ValueError('fold attribute must be either 0 or 1')
-            self._fold = val
-        else:
-            self._fold = val   #?????
-            self._datetime = enfold(self._datetime, fold=val)#self._datetime.replace(fold, val)
-            # updating object but not fold attr
+        if val not in {0, 1}:
+            raise ValueError('fold attribute must be either 0 or 1')
+        self._fold = val
+        self._datetime = enfold(self._datetime, fold=val)
+
 
     # mutation and duplication.
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -18,6 +18,8 @@ from dateutil.relativedelta import relativedelta
 
 from arrow import formatter, locales, parser, util
 
+# from util import NO_FOLD
+
 
 class Arrow(object):
     """An :class:`Arrow <arrow.arrow.Arrow>` object.

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import
 
 import datetime
-import sys
-
-from dateutil import tz as dateutil_tz
 
 
 def total_seconds(td):

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -6,8 +6,6 @@ import sys
 
 from dateutil import tz as dateutil_tz
 
-NO_FOLD = sys.version_info < (3, 6)
-
 
 def total_seconds(td):
     """Get total seconds for timedelta."""
@@ -63,15 +61,7 @@ except NameError:  # pragma: no cover
         return isinstance(s, str)
 
 
-def ensure_fold(dt):
-    # use enfold here
-    # is_ambiguous
-    pass
-
-
-def _calculate_fold():
-    # how do I deal with all the dt.fold in arrow.py - don't just apply method before
-    # read dateutil code
+class ImaginaryDatetimeWarning(UserWarning):
     pass
 
 

--- a/arrow/util.py
+++ b/arrow/util.py
@@ -2,6 +2,11 @@
 from __future__ import absolute_import
 
 import datetime
+import sys
+
+from dateutil import tz as dateutil_tz
+
+NO_FOLD = sys.version_info < (3, 6)
 
 
 def total_seconds(td):
@@ -56,6 +61,18 @@ except NameError:  # pragma: no cover
 
     def isstr(s):
         return isinstance(s, str)
+
+
+def ensure_fold(dt):
+    # use enfold here
+    # is_ambiguous
+    pass
+
+
+def _calculate_fold():
+    # how do I deal with all the dt.fold in arrow.py - don't just apply method before
+    # read dateutil code
+    pass
 
 
 __all__ = ["total_seconds", "is_timestamp", "isstr", "iso_to_gregorian"]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-        "python-dateutil",
+        "python-dateutil>=2.7.0",
         "backports.functools_lru_cache>=1.2.1;python_version=='2.7'",
     ],
     classifiers=[

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -296,10 +296,11 @@ class TestArrowAttribute:
     def test_fold(self):
 
         assert self.arrow.fold == 0
-
         self.arrow.fold = 1
-
         assert self.arrow.fold == 1
+
+        with pytest.raises(ValueError):
+            self.arrow.fold = 123
 
 class TestArrowComparison:
     @classmethod
@@ -590,15 +591,21 @@ class TestArrowConversion:
         result = arrow.Arrow(2018, 11, 4, 1, tzinfo="-08:00").to("US/Pacific").to("UTC")
         assert result == arrow.Arrow(2018, 11, 4, 9)
 
-    # regression test for #690 unsure of correct result here
-    # def test_to_israel_same_offset(self):
-    #     first = arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="+03:00")
-    #     print(first)
-    #     result = arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="+03:00").to("Israel")
-    #     print(result)
-    #     final=arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="Israel")
-    #     print(final)
-    #     assert result == arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="Israel")
+    # regression test for #690
+    def test_to_israel_same_offset(self):
+
+        result = arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="+03:00").to("Israel")
+        expected = arrow.Arrow(2019, 10, 27, 1, 21, 1, tzinfo="Israel")
+
+        assert result == expected
+        assert_datetime_equality(result, expected)
+
+    # issue 315
+    def test_anchorage_dst(self):
+        before = arrow.Arrow(2016, 3, 12).to("America/Anchorage")
+        after = arrow.Arrow(2016, 3, 15).to("America/Anchorage")
+
+        assert before.utcoffset() != after.utcoffset()
 
 
 class TestArrowPickling:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -302,6 +302,7 @@ class TestArrowAttribute:
         with pytest.raises(ValueError):
             self.arrow.fold = 123
 
+
 class TestArrowComparison:
     @classmethod
     def setup_class(cls):
@@ -809,7 +810,9 @@ class TestArrowShift:
         # likely needs fold attribute here for shift back, review imaginary dt in Paul's talk
         # maybe info not available yet!
         london = arrow.Arrow(2019, 10, 27, 2, 30, tzinfo="Europe/London")
-        assert london.shift(hours=-2) == arrow.Arrow(2019, 10, 27, 0, 30, tzinfo="Europe/London")
+        assert london.shift(hours=-2) == arrow.Arrow(
+            2019, 10, 27, 0, 30, tzinfo="Europe/London"
+        )
 
         canberra = arrow.Arrow(2018, 10, 7, 1, 30, tzinfo="Australia/Canberra")
         assert canberra.shift(hours=+1) == arrow.Arrow(
@@ -828,10 +831,10 @@ class TestArrowShift:
         )
 
         # NOTE very odd behaviour here -<Arrow [2011-12-31T23:00:00+14:00]>
-        #apia = arrow.Arrow(2011, 12, 31, 1, tzinfo="Pacific/Apia")
-        #assert apia.shift(hours=-2) == arrow.Arrow(
+        # apia = arrow.Arrow(2011, 12, 31, 1, tzinfo="Pacific/Apia")
+        # assert apia.shift(hours=-2) == arrow.Arrow(
         #    2011, 12, 29, 23, tzinfo="Pacific/Apia"
-        #)
+        # )
 
         # corrected 2018d tz database release, will fail in earlier versions
         # TODO dateutil 2.7.0 contains 2018c, is this really worth testing in arrow?
@@ -840,7 +843,9 @@ class TestArrowShift:
             1995, 1, 1, 12, 30, tzinfo="Pacific/Kiritimati"
         )
 
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason="unsupported before python3.6")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 6), reason="unsupported before python3.6"
+    )
     def shift_imaginary_seconds(self):
         # offset has a seconds component
         monrovia = arrow.Arrow(1972, 1, 6, 23, tzinfo="Africa/Monrovia")
@@ -1046,11 +1051,11 @@ class TestArrowRange:
         # avoid duplication in utc column
         # issue #72
 
-        before = arrow.Arrow(2018, 3, 10, 23, tzinfo='US/Pacific')
-        after = arrow.Arrow(2018, 3, 11, 4, tzinfo='US/Pacific')
+        before = arrow.Arrow(2018, 3, 10, 23, tzinfo="US/Pacific")
+        after = arrow.Arrow(2018, 3, 11, 4, tzinfo="US/Pacific")
 
-        pacific_range = [t for t in arrow.Arrow.range('hour', before, after)]
-        utc_range = [t.to('utc') for t in arrow.Arrow.range('hour', before, after)]
+        pacific_range = [t for t in arrow.Arrow.range("hour", before, after)]
+        utc_range = [t.to("utc") for t in arrow.Arrow.range("hour", before, after)]
 
         assert len(pacific_range) == len(set(pacific_range))
         assert len(utc_range) == len(set(utc_range))

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -72,6 +72,14 @@ class TestTestArrowInit:
         assert result._datetime == self.expected
         assert_datetime_equality(result._datetime, self.expected, 1)
 
+    def test_init_with_fold(self):
+        before = arrow.Arrow(2017, 10, 29, 2, 0, tzinfo="Europe/Stockholm")
+        after = arrow.Arrow(2017, 10, 29, 2, 0, tzinfo="Europe/Stockholm", fold=1)
+
+        # PEP-495 requires the equality below to be true
+        assert before == after
+        assert before.utcoffset() != after.utcoffset()
+
 
 class TestTestArrowFactory:
     def test_now(self):
@@ -568,6 +576,20 @@ class TestArrowConversion:
         assert arrow_from.to("UTC").datetime == self.expected
         assert arrow_from.to(tz.tzutc()).datetime == self.expected
 
+    def test_to_pacific_then_utc(self):
+        result = arrow.Arrow(2018, 11, 4, 1, tzinfo="-08:00").to("US/Pacific").to("UTC")
+        assert result == arrow.Arrow(2018, 11, 4, 9)
+
+    # regression test for #690 unsure of correct result here
+    # def test_to_israel_same_offset(self):
+    #     first = arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="+03:00")
+    #     print(first)
+    #     result = arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="+03:00").to("Israel")
+    #     print(result)
+    #     final=arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="Israel")
+    #     print(final)
+    #     assert result == arrow.Arrow(2019, 10, 27, 2, 21, 1, tzinfo="Israel")
+
 
 class TestArrowPickling:
     def test_pickle_and_unpickle(self):
@@ -758,7 +780,17 @@ class TestArrowShift:
             2013, 3, 31, 3, 10, tzinfo="Europe/Paris"
         )
 
+        # london
+
+        # 2015-10-06T02:00:00+02:00
+
+        # berlin = arrow.Arrow(2015)
+
+        # >> > arrow.get('2019-11-03 01:05:00-05:00').to('America/New_York')
+        # < Arrow[2019 - 11 - 03T01: 05:00 - 04: 00] >
+
         # likely needs fold attribute here for shift back, review imaginary dt in Paul's talk
+        # maybe info not available yet!
         # london = arrow.Arrow(2019, 10, 27, 1, 30, tzinfo="Europe/London")
         # assert london.shift(hours=+1) == arrow.Arrow(2019, 10, 27, 10, 30, tzinfo="Europe/London")
 
@@ -983,6 +1015,16 @@ class TestArrowRange:
 
         with pytest.raises(AttributeError):
             next(arrow.Arrow.range("abc", datetime.utcnow(), datetime.utcnow()))
+
+    # def test_imaginary(self):
+
+    # WHY!!!???? I thought this was fixed!
+    # (< Arrow[2018-03-11T00:00:00-08:00] >, < Arrow[2018-03-11T08:00:00+00:00] >)
+    # (< Arrow[2018-03-11T01:00:00-08:00] >, < Arrow[2018-03-11T09:00:00+00:00] >)
+    # (< Arrow[2018-03-11T02:00:00-07:00] >, < Arrow[2018-03-11T09:00:00+00:00] >)
+    # (< Arrow[2018-03-11T03:00:00-07:00] >, < Arrow[2018-03-11T10:00:00+00:00] >)
+    # (< Arrow[2018-03-11T04:00:00-07:00] >, < Arrow[2018-03-11T11:00:00+00:00] >)
+    # (< Arrow[2018-03-11T05:00:00-07:00] >, < Arrow[2018-03-11T12:00:00+00:00] >)
 
 
 class TestArrowSpanRange:

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1042,7 +1042,6 @@ class TestArrowRange:
         with pytest.raises(AttributeError):
             next(arrow.Arrow.range("abc", datetime.utcnow(), datetime.utcnow()))
 
-    @pytest.mark.xfail
     def test_imaginary(self):
         # avoid duplication in utc column
         # issue #72

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -821,8 +821,11 @@ class TestArrowShift:
             2011, 12, 31, 1, tzinfo="Pacific/Apia"
         )
 
-        # NOTE very odd behaviour here -<Arrow [2011-12-31T23:00:00+14:00]>
-        # How does dateutil.resolve_imaginary work here?
+        # NOTE very odd behaviour here -<Arrow [2011-12-30T23:00:00+14:00]>
+        # How does dateutil.resolve_imaginary work here? This dt should be resolved in the shift method.
+
+        # dateutil says that the method will always fall forward.
+
         # apia = arrow.Arrow(2011, 12, 31, 1, tzinfo="Pacific/Apia")
         # assert apia.shift(hours=-2) == arrow.Arrow(
         #    2011, 12, 29, 23, tzinfo="Pacific/Apia"deac
@@ -841,7 +844,7 @@ class TestArrowShift:
         )
 
     @pytest.mark.skipif(
-        sys.version_info < (3, 6), reason="unsupported before python3.6"
+        sys.version_info < (3, 6), reason="unsupported before python 3.6"
     )
     def shift_imaginary_seconds(self):
         # offset has a seconds component

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -7,6 +7,7 @@ import sys
 import time
 from datetime import date, datetime, timedelta
 
+import dateutil
 import pytest
 import pytz
 import simplejson as json
@@ -793,26 +794,16 @@ class TestArrowShift:
             2017, 3, 12, 3, 30, tzinfo="America/New_York"
         )
 
+        # pendulum example
         paris = arrow.Arrow(2013, 3, 31, 1, 50, tzinfo="Europe/Paris")
         assert paris.shift(minutes=+20) == arrow.Arrow(
             2013, 3, 31, 3, 10, tzinfo="Europe/Paris"
         )
 
-        # london
-
-        # 2015-10-06T02:00:00+02:00
-
-        # berlin = arrow.Arrow(2015)
-
-        # >> > arrow.get('2019-11-03 01:05:00-05:00').to('America/New_York')
-        # < Arrow[2019 - 11 - 03T01: 05:00 - 04: 00] >
-
-        # likely needs fold attribute here for shift back, review imaginary dt in Paul's talk
-        # maybe info not available yet!
         london = arrow.Arrow(2019, 10, 27, 2, 30, tzinfo="Europe/London")
-        assert london.shift(hours=-2) == arrow.Arrow(
-            2019, 10, 27, 0, 30, tzinfo="Europe/London"
-        )
+        before = london.shift(hours=-2)
+        assert before == arrow.Arrow(2019, 10, 27, 0, 30, tzinfo="Europe/London")
+        assert london.utcoffset() != before.utcoffset()
 
         canberra = arrow.Arrow(2018, 10, 7, 1, 30, tzinfo="Australia/Canberra")
         assert canberra.shift(hours=+1) == arrow.Arrow(
@@ -831,13 +822,19 @@ class TestArrowShift:
         )
 
         # NOTE very odd behaviour here -<Arrow [2011-12-31T23:00:00+14:00]>
+        # How does dateutil.resolve_imaginary work here?
         # apia = arrow.Arrow(2011, 12, 31, 1, tzinfo="Pacific/Apia")
         # assert apia.shift(hours=-2) == arrow.Arrow(
-        #    2011, 12, 29, 23, tzinfo="Pacific/Apia"
+        #    2011, 12, 29, 23, tzinfo="Pacific/Apia"deac
         # )
 
+    # TODO dateutil 2.7.0 contains 2018c, is this really worth testing in arrow?
+    @pytest.mark.skipif(
+        dateutil.__version__ < "2.7.1", reason="old tz database (2018d needed)"
+    )
+    def test_shift_kiritimati(self):
         # corrected 2018d tz database release, will fail in earlier versions
-        # TODO dateutil 2.7.0 contains 2018c, is this really worth testing in arrow?
+
         kiritimati = arrow.Arrow(1994, 12, 30, 12, 30, tzinfo="Pacific/Kiritimati")
         assert kiritimati.shift(days=+1) == arrow.Arrow(
             1995, 1, 1, 12, 30, tzinfo="Pacific/Kiritimati"

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -744,6 +744,52 @@ class TestArrowShift:
             2013, 5, 5, 12, 30, 45, 1
         )
 
+    def test_shift_imaginary(self):
+
+        # Avoid shifting into imaginary datetimes, take into account DST and other timezone changes.
+
+        new_york = arrow.Arrow(2017, 3, 12, 1, 30, tzinfo="America/New_York")
+        assert new_york.shift(hours=+1) == arrow.Arrow(
+            2017, 3, 12, 3, 30, tzinfo="America/New_York"
+        )
+
+        paris = arrow.Arrow(2013, 3, 31, 1, 50, tzinfo="Europe/Paris")
+        assert paris.shift(minutes=+20) == arrow.Arrow(
+            2013, 3, 31, 3, 10, tzinfo="Europe/Paris"
+        )
+
+        # likely needs fold attribute here for shift back, review imaginary dt in Paul's talk
+        # london = arrow.Arrow(2019, 10, 27, 1, 30, tzinfo="Europe/London")
+        # assert london.shift(hours=+1) == arrow.Arrow(2019, 10, 27, 10, 30, tzinfo="Europe/London")
+
+        canberra = arrow.Arrow(2018, 10, 7, 1, 30, tzinfo="Australia/Canberra")
+        assert canberra.shift(hours=+1) == arrow.Arrow(
+            2018, 10, 7, 3, 30, tzinfo="Australia/Canberra"
+        )
+
+        kiev = arrow.Arrow(2018, 3, 25, 2, 30, tzinfo="Europe/Kiev")
+        assert kiev.shift(hours=+1) == arrow.Arrow(
+            2018, 3, 25, 4, 30, tzinfo="Europe/Kiev"
+        )
+
+        # Edge case, the entire day of 2011-12-30 is imaginary in this zone!
+        apia = arrow.Arrow(2011, 12, 29, 23, tzinfo="Pacific/Apia")
+        assert apia.shift(hours=+2) == arrow.Arrow(
+            2011, 12, 31, 1, tzinfo="Pacific/Apia"
+        )
+
+        # corrected 2018d tz database release, will fail in earlier versions
+        kiritimati = arrow.Arrow(1994, 12, 31, 12, 30, tzinfo="Pacific/Kiritimati")
+        assert kiritimati.shift(days=+1) == arrow.Arrow(
+            1995, 1, 1, 12, 30, tzinfo="Pacific/Kiritimati"
+        )
+
+        # offset has a seconds component
+        monrovia = arrow.Arrow(1972, 1, 6, 23, tzinfo="Africa/Monrovia")
+        assert monrovia.shift(hours=+1, minutes=+30) == arrow.Arrow(
+            1972, 1, 7, 1, 14, 30, tzinfo="Africa/Monrovia"
+        )
+
 
 class TestArrowRange:
     def test_year(self):

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -79,9 +79,6 @@ class TestTestArrowInit:
         assert hasattr(before, "fold")
         assert hasattr(after, "fold")
 
-        assert hasattr(before._datetime, "fold")
-        assert hasattr(after._datetime, "fold")
-
         # PEP-495 requires the equality below to be true
         assert before == after
         assert before.utcoffset() != after.utcoffset()
@@ -296,6 +293,13 @@ class TestArrowAttribute:
 
         assert result == self.arrow.microsecond
 
+    def test_fold(self):
+
+        assert self.arrow.fold == 0
+
+        self.arrow.fold = 1
+
+        assert self.arrow.fold == 1
 
 class TestArrowComparison:
     @classmethod


### PR DESCRIPTION
## Pull Request Checklist

<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

## Description of Changes
This PR adds support for handling ambiguous and imaginary datetimes via the fold attribute [PEP 495](https://www.python.org/dev/peps/pep-0495/) and dateutil [methods](https://dateutil.readthedocs.io/en/stable/tz.html#dateutil.tz.enfold). I'm happy to admit that without the `dateutil.tz.enfold()` method this feature would have been much harder to backport into 2.7/3.5.

There are several design decisions I've made here that need to be looked at carefully.

- There is now a requirement for python-dateutil >= 2.7.0, before it was simply required.
- The `arrow.Arrow()` constructor will issue a warning but not prevent creation of imaginary datetimes.
- Various other methods will prevent creation of these imaginary datetimes and will resolve them to existing datetimes with no warning to the user.

### TODO
- [ ] Decide what to do with `span` method, `interval`, `span_range`, `ceil` and `floor` all depend upon it.
- [ ] Understand `Pacific/Apia` edge case.
- [ ] Consider adding a method to automatically resolve imaginary datetimes.
- [ ] Cleanup code.
- [ ] Bulk out tests and link to issues.
- [x] Add pendulum dst example, coverage 100%.
- [ ] Documentation updates where needed.

ref #488 
closes #72 
closes #315 
closes #368 
closes #424 
closes #476 
closes #509 
closes #686 
closes #690 