### PR TITLE
Allow formatting with 'x' token

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -16,7 +16,7 @@ class DateTimeFormatter(object):
     # emulated in Python's re library, see https://stackoverflow.com/a/13577411/2701578
 
     _FORMAT_RE = re.compile(
-        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|W)"
+        r"(\[(?:(?=(?P<literal>[^]]))(?P=literal))*\]|YYY?Y?|MM?M?M?|Do|DD?D?D?|d?dd?d?|HH?|hh?|mm?|ss?|SS?S?S?S?S?|ZZ?Z?|a|A|X|x|W)"
     )
 
     def __init__(self, locale="en_us"):
@@ -99,6 +99,10 @@ class DateTimeFormatter(object):
 
         if token == "X":
             return str(calendar.timegm(dt.utctimetuple()))
+
+        if token == "x":
+            ts = calendar.timegm(dt.utctimetuple()) + (dt.microsecond / 1000000)
+            return str(int(ts * 1000000))
 
         if token == "ZZZ":
             return dt.tzname()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -107,7 +107,24 @@ class TestDateTimeFormatterFormatToken:
 
         timestamp = time.time()
         dt = datetime.utcfromtimestamp(timestamp)
+
         assert self.formatter._format_token(dt, "X") == str(int(timestamp))
+
+        # time.time() may return a float with greater than 6 digits of precision
+        # time_parts = str(timestamp).split(".")
+        # if len(time_parts[1]) > 6:
+        #     shortened = time_parts[1][:6]
+        #     truncated_timestamp = time_parts[0] + "." + shortened
+        #     timestamp = float(truncated_timestamp)
+        #
+        # assert self.formatter._format_token(dt, "x") == str(int(timestamp*1000000))
+
+        # TODO failing test for discussion with Jad
+        bad_timestamp = 1585668666.7198436
+        dt = datetime.utcfromtimestamp(bad_timestamp)
+        assert self.formatter._format_token(dt, "x") == str(
+            int(bad_timestamp * 1000000)
+        )
 
     def test_timezone(self):
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -107,7 +107,6 @@ class TestDateTimeFormatterFormatToken:
 
         timestamp = time.time()
         dt = datetime.utcfromtimestamp(timestamp)
-
         assert self.formatter._format_token(dt, "X") == str(int(timestamp))
 
         # time.time() may return a float with greater than 6 digits of precision

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -111,20 +111,8 @@ class TestDateTimeFormatterFormatToken:
         assert self.formatter._format_token(dt, "X") == str(int(timestamp))
 
         # time.time() may return a float with greater than 6 digits of precision
-        # time_parts = str(timestamp).split(".")
-        # if len(time_parts[1]) > 6:
-        #     shortened = time_parts[1][:6]
-        #     truncated_timestamp = time_parts[0] + "." + shortened
-        #     timestamp = float(truncated_timestamp)
-        #
-        # assert self.formatter._format_token(dt, "x") == str(int(timestamp*1000000))
-
-        # TODO failing test for discussion with Jad
-        bad_timestamp = 1585668666.7198436
-        dt = datetime.utcfromtimestamp(bad_timestamp)
-        assert self.formatter._format_token(dt, "x") == str(
-            int(bad_timestamp * 1000000)
-        )
+        rounded_ts = str(round(timestamp * 1000000))
+        assert self.formatter._format_token(dt, "x") == rounded_ts.format("{f}")
 
     def test_timezone(self):
 


### PR DESCRIPTION
<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

There's a failing test which we need to discuss, otherwise this is working ok.

```shell
(arrow) chris@ThinkPad:~/arrow$ python
Python 3.7.4 (default, Sep 19 2019, 11:01:37) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> adt=arrow.utcnow()
>>> adt.format("x")
'1585669870688329'
>>> adt.format("X")
'1585669870'
```