### PR TITLE
Consolidate German locales and add missing 'week'/'weeks' localization

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -29,7 +29,7 @@ def get_locale_by_class_name(name):
     :param name: the name of the locale class.
 
     """
-    locale_cls = globals()[name]
+    locale_cls = globals().get(name)
 
     if locale_cls is None:
         raise ValueError("Unsupported locale '{}'".format(name))

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1665,6 +1665,8 @@ class DeutschBaseLocale(Locale):
         "hours": "{0} Stunden",
         "day": "einem Tag",
         "days": "{0} Tagen",
+        "week": "einer Woche",
+        "weeks": "{0} Wochen",
         "month": "einem Monat",
         "months": "{0} Monaten",
         "year": "einem Jahr",
@@ -1675,6 +1677,7 @@ class DeutschBaseLocale(Locale):
     timeframes_only_distance["minute"] = "eine Minute"
     timeframes_only_distance["hour"] = "eine Stunde"
     timeframes_only_distance["day"] = "ein Tag"
+    timeframes_only_distance["week"] = "eine Woche"
     timeframes_only_distance["month"] = "ein Monat"
     timeframes_only_distance["year"] = "ein Jahr"
 

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1753,6 +1753,11 @@ class GermanLocale(GermanBaseLocale, Locale):
     names = ["de", "de_de"]
 
 
+class SwissLocale(GermanBaseLocale, Locale):
+
+    names = ["de_ch"]
+
+
 class AustrianLocale(GermanBaseLocale, Locale):
 
     names = ["de_at"]
@@ -3768,77 +3773,6 @@ class RomanshLocale(Locale):
     ]
 
     day_abbreviations = ["", "gli", "ma", "me", "gie", "ve", "so", "du"]
-
-
-class SwissLocale(Locale):
-
-    names = ["de", "de_ch"]
-
-    past = "vor {0}"
-    future = "in {0}"
-
-    timeframes = {
-        "now": "gerade eben",
-        "second": "eine Sekunde",
-        "seconds": "{0} Sekunden",
-        "minute": "einer Minute",
-        "minutes": "{0} Minuten",
-        "hour": "einer Stunde",
-        "hours": "{0} Stunden",
-        "day": "einem Tag",
-        "days": "{0} Tagen",
-        "week": "einer Woche",
-        "weeks": "{0} Wochen",
-        "month": "einem Monat",
-        "months": "{0} Monaten",
-        "year": "einem Jahr",
-        "years": "{0} Jahren",
-    }
-
-    month_names = [
-        "",
-        "Januar",
-        "Februar",
-        "März",
-        "April",
-        "Mai",
-        "Juni",
-        "Juli",
-        "August",
-        "September",
-        "Oktober",
-        "November",
-        "Dezember",
-    ]
-
-    month_abbreviations = [
-        "",
-        "Jan",
-        "Feb",
-        "Mär",
-        "Apr",
-        "Mai",
-        "Jun",
-        "Jul",
-        "Aug",
-        "Sep",
-        "Okt",
-        "Nov",
-        "Dez",
-    ]
-
-    day_names = [
-        "",
-        "Montag",
-        "Dienstag",
-        "Mittwoch",
-        "Donnerstag",
-        "Freitag",
-        "Samstag",
-        "Sonntag",
-    ]
-
-    day_abbreviations = ["", "Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
 
 
 class RomanianLocale(Locale):

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1737,11 +1737,13 @@ class GermanBaseLocale(Locale):
         :param only_distance: return only distance eg: "11 seconds" without "in" or "ago" keywords
         """
 
-        humanized = self.timeframes_only_distance[timeframe].format(trunc(abs(delta)))
-
         if not only_distance:
-            humanized = self._format_timeframe(timeframe, delta)
-            humanized = self._format_relative(humanized, timeframe, delta)
+            return super(GermanBaseLocale, self).describe(
+                timeframe, delta, only_distance
+            )
+
+        # German uses a different case without 'in' or 'ago'
+        humanized = self.timeframes_only_distance[timeframe].format(trunc(abs(delta)))
 
         return humanized
 

--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1649,7 +1649,7 @@ class MacedonianLocale(SlavicBaseLocale):
     ]
 
 
-class DeutschBaseLocale(Locale):
+class GermanBaseLocale(Locale):
 
     past = "vor {0}"
     future = "in {0}"
@@ -1746,12 +1746,12 @@ class DeutschBaseLocale(Locale):
         return humanized
 
 
-class GermanLocale(DeutschBaseLocale, Locale):
+class GermanLocale(GermanBaseLocale, Locale):
 
     names = ["de", "de_de"]
 
 
-class AustrianLocale(DeutschBaseLocale, Locale):
+class AustrianLocale(GermanBaseLocale, Locale):
 
     names = ["de_at"]
 

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -53,6 +53,22 @@ class TestModule:
 
         assert result == mock_locale
 
+    def test_get_locale_by_class_name(self, mocker):
+        mock_locale_cls = mocker.Mock()
+        mock_locale_obj = mock_locale_cls.return_value = mocker.Mock()
+
+        globals_fn = mocker.Mock()
+        globals_fn.return_value = {"NonExistentLocale": mock_locale_cls}
+
+        with pytest.raises(ValueError):
+            arrow.locales.get_locale_by_class_name("NonExistentLocale")
+
+        mocker.patch.object(locales, "globals", globals_fn)
+        result = arrow.locales.get_locale_by_class_name("NonExistentLocale")
+
+        mock_locale_cls.assert_called_once_with()
+        assert result == mock_locale_obj
+
     def test_locales(self):
 
         assert len(locales._locales) > 0

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -489,6 +489,11 @@ class TestGermanLocale:
         assert self.locale.describe("year", only_distance=True) == "ein Jahr"
         assert self.locale.describe("year", only_distance=False) == "in einem Jahr"
 
+    def test_weekday(self):
+        dt = arrow.Arrow(2015, 4, 11, 17, 30, 00)
+        assert self.locale.day_name(dt.isoweekday()) == "Samstag"
+        assert self.locale.day_abbreviation(dt.isoweekday()) == "Sa"
+
 
 @pytest.mark.usefixtures("lang_locale")
 class TestHungarianLocale:
@@ -549,16 +554,6 @@ class TestBengaliLocale:
         assert self.locale._ordinal_number(11) == "11তম"
         assert self.locale._ordinal_number(42) == "42তম"
         assert self.locale._ordinal_number(-1) is None
-
-
-@pytest.mark.usefixtures("lang_locale")
-class TestSwissLocale:
-    def test_ordinal_number(self):
-        dt = arrow.Arrow(2015, 4, 11, 17, 30, 00)
-
-        assert self.locale._format_timeframe("minute", 1) == "einer Minute"
-        assert self.locale._format_timeframe("hour", 1) == "einer Stunde"
-        assert self.locale.day_abbreviation(dt.isoweekday()) == "Sa"
 
 
 @pytest.mark.usefixtures("lang_locale")

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -482,6 +482,8 @@ class TestGermanLocale:
         assert self.locale.describe("hour", only_distance=False) == "in einer Stunde"
         assert self.locale.describe("day", only_distance=True) == "ein Tag"
         assert self.locale.describe("day", only_distance=False) == "in einem Tag"
+        assert self.locale.describe("week", only_distance=True) == "eine Woche"
+        assert self.locale.describe("week", only_distance=False) == "in einer Woche"
         assert self.locale.describe("month", only_distance=True) == "ein Monat"
         assert self.locale.describe("month", only_distance=False) == "in einem Monat"
         assert self.locale.describe("year", only_distance=True) == "ein Jahr"


### PR DESCRIPTION
German locales are missing translations for the week/weeks granularities.

While working on that, I noticed that `SwissLocale` has them and that it declared itself responsible for plain `de` (as well as `GermanLocale`), so it's a question of chance which one is used to localize for `de` (as opposed to `de_de` or `de_ch`). As I couldn't spot an effective difference between the two, this PR merges both into one class (for `de`, `de_ch`, `de_de`). Additionally, I renamed `DeutschBaseLocale` to `GermanBaseLocale` for consistency and, because its purpose wasn't clear to me right away, straightened out the custom `describe()` method.

/cc @href You might want to take a look at this, please check if I missed anything regarding the equivalence of `GermanLocale` and `SwissLocale`.

## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

* Add week/weeks granularity to German locales.
* Rename `DeutschBaseLocale` to `GermanBaseLocale` for consistency.
* Consolidate `GermanLocale` and `SwissLocale` under the former as they seem to be equivalent.
* Clarify purpose `GermanBaseLocale.describe()` and optimize.