### PR TITLE
Added cookie, rfc822, rfc850, and rfc1036 to built-in formats

### DIFF
--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -120,3 +120,79 @@ class DateTimeFormatter(object):
         if token == "W":
             year, week, day = dt.isocalendar()
             return "{}-W{:02d}-{}".format(year, week, day)
+
+
+    # COOKIE FORMAT: 'Thursday, 25-Dec-1975 14:15:16 EST'
+    def _format_cookie(self, dt):
+        # Date information
+        weekday = self._format_token(dt, "dddd")
+        day = self._format_token(dt, "DD")
+        month = self._format_token(dt, "MMM")
+        year = self._format_token(dt, "YYYY")
+        
+        # Time information 
+        hour = self._format_token(dt, "HH")
+        minute = self._format_token(dt, "mm")
+        second = self._format_token(dt, "ss")
+        timezone = self._format_token(dt, "ZZZ")
+        
+        day_format = weekday + ", " + day + "-" + month + "-" + year + " " 
+        time_format = hour + ":" + minute + ":" + second + " " + timezone
+        return day_format + time_format
+
+
+    # rfc822 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
+    def _format_rfc822(self, dt):
+        # Date information
+        weekday = self._format_token(dt, "ddd")
+        day = self._format_token(dt, "DD")
+        month = self._format_token(dt, "MMM")
+        year = self._format_token(dt, "YY")
+        
+        # Time info
+        hour = self._format_token(dt, "HH")
+        minute = self._format_token(dt, "mm")
+        second = self._format_token(dt, "ss")
+        timezone = self._format_token(dt, "Z")
+        
+        day_format = weekday + ", " + day + " " + month + " " + year + " " 
+        time_format = hour + ":" + minute + ":" + second + " " + timezone
+        return day_format + time_format
+
+
+    # rfc850 FORMAT: 'Thursday, 25-Dec-75 14:15:16 EST'
+    def _format_rfc850(self, dt):
+        # Date information
+        weekday = self._format_token(dt, "dddd")
+        day = self._format_token(dt, "DD")
+        month = self._format_token(dt, "MMM")
+        year = self._format_token(dt, "YY")
+        
+        # Time information 
+        hour = self._format_token(dt, "HH")
+        minute = self._format_token(dt, "mm")
+        second = self._format_token(dt, "ss")
+        timezone = self._format_token(dt, "ZZZ")
+        
+        day_format = weekday + ", " + day + "-" + month + "-" + year + " " 
+        time_format = hour + ":" + minute + ":" + second + " " + timezone
+        return day_format + time_format
+
+
+    #  rfc1036 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
+    def _format_rfc1036(self, dt):
+        # Date information
+        weekday = self._format_token(dt, "ddd")
+        day = self._format_token(dt, "DD")
+        month = self._format_token(dt, "MMM")
+        year = self._format_token(dt, "YY")
+        
+        # Time info
+        hour = self._format_token(dt, "HH")
+        minute = self._format_token(dt, "mm")
+        second = self._format_token(dt, "ss")
+        timezone = self._format_token(dt, "Z")
+        
+        day_format = weekday + ", " + day + " " + month + " " + year + " " 
+        time_format = hour + ":" + minute + ":" + second + " " + timezone
+        return day_format + time_format

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -123,16 +123,16 @@ class DateTimeFormatter(object):
 
     # COOKIE FORMAT: 'Thursday, 25-Dec-1975 14:15:16 EST'
     def format_cookie(cls, dt):
-        return cls.format(dt, 'dddd, DD-MMM-YYYY HH:mm:ss ZZZ')
+        return cls.format(dt, "dddd, DD-MMM-YYYY HH:mm:ss ZZZ")
 
     # rfc822 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
     def format_rfc822(cls, dt):
-        return cls.format(dt, 'ddd, DD MMM YY HH:mm:ss Z')
+        return cls.format(dt, "ddd, DD MMM YY HH:mm:ss Z")
 
     # rfc850 FORMAT: 'Thursday, 25-Dec-75 14:15:16 EST'
     def format_rfc850(cls, dt):
-        return cls.format(dt, 'dddd, DD-MMM-YY HH:mm:ss ZZZ')
+        return cls.format(dt, "dddd, DD-MMM-YY HH:mm:ss ZZZ")
 
     #  rfc1036 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
     def format_rfc1036(cls, dt):
-        return cls.format(dt, 'ddd, DD MMM YY HH:mm:ss Z')
+        return cls.format(dt, "ddd, DD MMM YY HH:mm:ss Z")

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -121,7 +121,6 @@ class DateTimeFormatter(object):
             year, week, day = dt.isocalendar()
             return "{}-W{:02d}-{}".format(year, week, day)
 
-
     # COOKIE FORMAT: 'Thursday, 25-Dec-1975 14:15:16 EST'
     def _format_cookie(self, dt):
         # Date information
@@ -129,17 +128,16 @@ class DateTimeFormatter(object):
         day = self._format_token(dt, "DD")
         month = self._format_token(dt, "MMM")
         year = self._format_token(dt, "YYYY")
-        
-        # Time information 
+
+        # Time information
         hour = self._format_token(dt, "HH")
         minute = self._format_token(dt, "mm")
         second = self._format_token(dt, "ss")
         timezone = self._format_token(dt, "ZZZ")
-        
-        day_format = weekday + ", " + day + "-" + month + "-" + year + " " 
-        time_format = hour + ":" + minute + ":" + second + " " + timezone
-        return day_format + time_format
 
+        return "{}, {}-{}-{} {}:{}:{} {}".format(
+            weekday, day, month, year, hour, minute, second, timezone
+        )
 
     # rfc822 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
     def _format_rfc822(self, dt):
@@ -148,17 +146,16 @@ class DateTimeFormatter(object):
         day = self._format_token(dt, "DD")
         month = self._format_token(dt, "MMM")
         year = self._format_token(dt, "YY")
-        
+
         # Time info
         hour = self._format_token(dt, "HH")
         minute = self._format_token(dt, "mm")
         second = self._format_token(dt, "ss")
         timezone = self._format_token(dt, "Z")
-        
-        day_format = weekday + ", " + day + " " + month + " " + year + " " 
-        time_format = hour + ":" + minute + ":" + second + " " + timezone
-        return day_format + time_format
 
+        return "{}, {} {} {} {}:{}:{} {}".format(
+            weekday, day, month, year, hour, minute, second, timezone
+        )
 
     # rfc850 FORMAT: 'Thursday, 25-Dec-75 14:15:16 EST'
     def _format_rfc850(self, dt):
@@ -167,17 +164,16 @@ class DateTimeFormatter(object):
         day = self._format_token(dt, "DD")
         month = self._format_token(dt, "MMM")
         year = self._format_token(dt, "YY")
-        
-        # Time information 
+
+        # Time information
         hour = self._format_token(dt, "HH")
         minute = self._format_token(dt, "mm")
         second = self._format_token(dt, "ss")
         timezone = self._format_token(dt, "ZZZ")
-        
-        day_format = weekday + ", " + day + "-" + month + "-" + year + " " 
-        time_format = hour + ":" + minute + ":" + second + " " + timezone
-        return day_format + time_format
 
+        return "{}, {}-{}-{} {}:{}:{} {}".format(
+            weekday, day, month, year, hour, minute, second, timezone
+        )
 
     #  rfc1036 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
     def _format_rfc1036(self, dt):
@@ -186,13 +182,13 @@ class DateTimeFormatter(object):
         day = self._format_token(dt, "DD")
         month = self._format_token(dt, "MMM")
         year = self._format_token(dt, "YY")
-        
+
         # Time info
         hour = self._format_token(dt, "HH")
         minute = self._format_token(dt, "mm")
         second = self._format_token(dt, "ss")
         timezone = self._format_token(dt, "Z")
-        
-        day_format = weekday + ", " + day + " " + month + " " + year + " " 
-        time_format = hour + ":" + minute + ":" + second + " " + timezone
-        return day_format + time_format
+
+        return "{}, {} {} {} {}:{}:{} {}".format(
+            weekday, day, month, year, hour, minute, second, timezone
+        )

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -122,73 +122,17 @@ class DateTimeFormatter(object):
             return "{}-W{:02d}-{}".format(year, week, day)
 
     # COOKIE FORMAT: 'Thursday, 25-Dec-1975 14:15:16 EST'
-    def _format_cookie(self, dt):
-        # Date information
-        weekday = self._format_token(dt, "dddd")
-        day = self._format_token(dt, "DD")
-        month = self._format_token(dt, "MMM")
-        year = self._format_token(dt, "YYYY")
-
-        # Time information
-        hour = self._format_token(dt, "HH")
-        minute = self._format_token(dt, "mm")
-        second = self._format_token(dt, "ss")
-        timezone = self._format_token(dt, "ZZZ")
-
-        return "{}, {}-{}-{} {}:{}:{} {}".format(
-            weekday, day, month, year, hour, minute, second, timezone
-        )
+    def format_cookie(cls, dt):
+        return cls.format(dt, 'dddd, DD-MMM-YYYY HH:mm:ss ZZZ')
 
     # rfc822 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
-    def _format_rfc822(self, dt):
-        # Date information
-        weekday = self._format_token(dt, "ddd")
-        day = self._format_token(dt, "DD")
-        month = self._format_token(dt, "MMM")
-        year = self._format_token(dt, "YY")
-
-        # Time info
-        hour = self._format_token(dt, "HH")
-        minute = self._format_token(dt, "mm")
-        second = self._format_token(dt, "ss")
-        timezone = self._format_token(dt, "Z")
-
-        return "{}, {} {} {} {}:{}:{} {}".format(
-            weekday, day, month, year, hour, minute, second, timezone
-        )
+    def format_rfc822(cls, dt):
+        return cls.format(dt, 'ddd, DD MMM YY HH:mm:ss Z')
 
     # rfc850 FORMAT: 'Thursday, 25-Dec-75 14:15:16 EST'
-    def _format_rfc850(self, dt):
-        # Date information
-        weekday = self._format_token(dt, "dddd")
-        day = self._format_token(dt, "DD")
-        month = self._format_token(dt, "MMM")
-        year = self._format_token(dt, "YY")
-
-        # Time information
-        hour = self._format_token(dt, "HH")
-        minute = self._format_token(dt, "mm")
-        second = self._format_token(dt, "ss")
-        timezone = self._format_token(dt, "ZZZ")
-
-        return "{}, {}-{}-{} {}:{}:{} {}".format(
-            weekday, day, month, year, hour, minute, second, timezone
-        )
+    def format_rfc850(cls, dt):
+        return cls.format(dt, 'dddd, DD-MMM-YY HH:mm:ss ZZZ')
 
     #  rfc1036 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
-    def _format_rfc1036(self, dt):
-        # Date information
-        weekday = self._format_token(dt, "ddd")
-        day = self._format_token(dt, "DD")
-        month = self._format_token(dt, "MMM")
-        year = self._format_token(dt, "YY")
-
-        # Time info
-        hour = self._format_token(dt, "HH")
-        minute = self._format_token(dt, "mm")
-        second = self._format_token(dt, "ss")
-        timezone = self._format_token(dt, "Z")
-
-        return "{}, {} {} {} {}:{}:{} {}".format(
-            weekday, day, month, year, hour, minute, second, timezone
-        )
+    def format_rfc1036(cls, dt):
+        return cls.format(dt, 'ddd, DD MMM YY HH:mm:ss Z')

--- a/arrow/formatter.py
+++ b/arrow/formatter.py
@@ -136,3 +136,15 @@ class DateTimeFormatter(object):
     #  rfc1036 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
     def format_rfc1036(cls, dt):
         return cls.format(dt, "ddd, DD MMM YY HH:mm:ss Z")
+
+    # rfc1123 FORMAT: 'Thu, 25 Dec 1975 14:15:16 -0500'
+    def format_rfc1123(cls, dt):
+        return cls.format(dt, "ddd, DD MMM YYYY HH:mm:ss Z")
+
+    # rfc2822 format: 'Thu, 25 Dec 1975 14:15:16 -0500'
+    def format_rfc2822(cls, dt):
+        return cls.format(dt, "ddd, DD MMM YYYY HH:mm:ss Z")
+
+    # rss format: 'Thu, 25 Dec 1975 14:15:16 -0500'
+    def format_rss(cls, dt):
+        return cls.format(dt, "ddd, DD MMM YYYY HH:mm:ss Z")

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytz
 from dateutil import tz as dateutil_tz
-from dateutil.tz import *
+
 from arrow import formatter
 
 from .utils import make_full_tz_list
@@ -203,83 +203,100 @@ class TestDateTimeFormatterFormatToken:
 
         # Escaping is atomic: brackets inside brackets are treated literally
         assert self.formatter.format(datetime(1, 1, 1), "[[[ ]]") == "[[ ]"
-    
 
-    # COOKIE FORMAT: 'Thursday, 25-Dec-1975 14:15:16 EST'
+
+class TestDateTimeFormatterPremadeFormats:
+    def setup_class(cls):
+        cls.formatter = formatter.DateTimeFormatter()
+
+    # cookie format: 'Thursday, 25-Dec-1975 14:15:16 EST'
     def test_cookie(self):
         for full_name in make_full_tz_list():
             # Testing functionality of basic values and timezones
-            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
-            )
-            abbreviation = dt.tzname()
+            dt = datetime(
+                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
             correct_timezone = self.formatter._format_token(dt, "ZZZ")
-            assert self.formatter._format_cookie(dt) == "Thursday, 25-Dec-1975 14:15:16 " + correct_timezone
-
-            # Testing that single digit values return with a 0 in front 
-            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
+            assert (
+                self.formatter._format_cookie(dt)
+                == "Thursday, 25-Dec-1975 14:15:16 " + correct_timezone
             )
-            abbreviation = dt_single_digit.tzname()
+
+            # Testing that single digit values return with a 0 in front
+            dt_single_digit = datetime(
+                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
             correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
-            assert self.formatter._format_cookie(dt_single_digit) == "Wednesday, 05-Feb-1975 04:05:06 " + correct_timezone
+            assert (
+                self.formatter._format_cookie(dt_single_digit)
+                == "Wednesday, 05-Feb-1975 04:05:06 " + correct_timezone
+            )
 
-
-    # rfc833 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
-    def test_rfc_822(self): 
+    # rfc833 format: 'Thu, 25 Dec 75 14:15:16 -0500'
+    def test_rfc_822(self):
         for full_name in make_full_tz_list():
             # Testing functionality of basic values and timezones
-            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
-            )
-            abbreviation = dt.tzname()
+            dt = datetime(
+                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
             correct_timezone = self.formatter._format_token(dt, "Z")
-            assert self.formatter._format_rfc822(dt) == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
-
-            # Testing that single digit values return with a 0 in front 
-            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
+            assert (
+                self.formatter._format_rfc822(dt)
+                == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
             )
-            abbreviation = dt_single_digit.tzname()
-            correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
-            assert self.formatter._format_rfc822(dt_single_digit) == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
-    
 
-    # rfc850 FORMAT: 'Thursday, 25-Dec-75 14:15:16 EST'
-    def test_rfc_850(self): 
+            # Testing that single digit values return with a 0 in front
+            dt_single_digit = datetime(
+                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
+            correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
+            assert (
+                self.formatter._format_rfc822(dt_single_digit)
+                == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+            )
+
+    # rfc850 format: 'Thursday, 25-Dec-75 14:15:16 EST'
+    def test_rfc_850(self):
         for full_name in make_full_tz_list():
             # Testing functionality of basic values and timezones
-            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
-            )
-            abbreviation = dt.tzname()
+            dt = datetime(
+                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
             correct_timezone = self.formatter._format_token(dt, "ZZZ")
-            assert self.formatter._format_rfc850(dt) == "Thursday, 25-Dec-75 14:15:16 " + correct_timezone
-
-            # Testing that single digit values return with a 0 in front 
-            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
+            assert (
+                self.formatter._format_rfc850(dt)
+                == "Thursday, 25-Dec-75 14:15:16 " + correct_timezone
             )
-            abbreviation = dt_single_digit.tzname()
-            correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
-            assert self.formatter._format_rfc850(dt_single_digit) == "Wednesday, 05-Feb-75 04:05:06 " + correct_timezone
-    
 
-    #  rfc1036 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
-    def test_rfc_1036(self): 
+            # Testing that single digit values return with a 0 in front
+            dt_single_digit = datetime(
+                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
+            correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
+            assert (
+                self.formatter._format_rfc850(dt_single_digit)
+                == "Wednesday, 05-Feb-75 04:05:06 " + correct_timezone
+            )
+
+    #  rfc1036 format: 'Thu, 25 Dec 75 14:15:16 -0500'
+    def test_rfc_1036(self):
         for full_name in make_full_tz_list():
             # Testing functionality of basic values and timezones
-            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
-            )
-            abbreviation = dt.tzname()
+            dt = datetime(
+                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
             correct_timezone = self.formatter._format_token(dt, "Z")
-            assert self.formatter._format_rfc1036(dt) == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
-
-            # Testing that single digit values return with a 0 in front 
-            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
-                tzinfo=dateutil_tz.gettz(full_name)
+            assert (
+                self.formatter._format_rfc1036(dt)
+                == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
             )
-            abbreviation = dt_single_digit.tzname()
+
+            # Testing that single digit values return with a 0 in front
+            dt_single_digit = datetime(
+                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
+            ).replace(tzinfo=dateutil_tz.gettz(full_name))
             correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
-            assert self.formatter._format_rfc1036(dt_single_digit) == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+            assert (
+                self.formatter._format_rfc1036(dt_single_digit)
+                == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+            )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -2,19 +2,15 @@
 import time
 from datetime import datetime
 
+import pytest
 import pytz
 from dateutil import tz as dateutil_tz
-
-from arrow import formatter
 
 from .utils import make_full_tz_list
 
 
+@pytest.mark.usefixtures("arrow_formatter")
 class TestDateTimeFormatterFormatToken:
-    @classmethod
-    def setup_class(cls):
-        cls.formatter = formatter.DateTimeFormatter()
-
     def test_format(self):
 
         dt = datetime(2013, 2, 5, 12, 32, 51)
@@ -205,85 +201,60 @@ class TestDateTimeFormatterFormatToken:
         assert self.formatter.format(datetime(1, 1, 1), "[[[ ]]") == "[[ ]"
 
 
+@pytest.mark.usefixtures("arrow_formatter")
 class TestDateTimeFormatterPremadeFormats:
-    def setup_class(cls):
-        cls.formatter = formatter.DateTimeFormatter()
-
     # cookie format: 'Thursday, 25-Dec-1975 14:15:16 EST'
     def test_cookie(self):
-        tz = list(make_full_tz_list())[0]
+        tz = "America/New_York"
         dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
-
-        correct_timezone = self.formatter._format_token(dt, "ZZZ")
-        assert (
-            self.formatter.format_cookie(dt)
-            == "Thursday, 25-Dec-1975 14:15:16 " + correct_timezone
-        )
+        assert self.formatter.format_cookie(dt) == "Thursday, 25-Dec-1975 14:15:16 EST"
 
         # Testing that single digit values return with a 0 in front
-        dt_single_digit = datetime(
-            1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
-        ).replace(tzinfo=dateutil_tz.gettz(tz))
-        correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
+        dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
         assert (
             self.formatter.format_cookie(dt_single_digit)
-            == "Wednesday, 05-Feb-1975 04:05:06 " + correct_timezone
+            == "Wednesday, 05-Feb-1975 04:05:06 EST"
         )
 
     # rfc833 format: 'Thu, 25 Dec 75 14:15:16 -0500'
     def test_rfc_822(self):
-        tz = list(make_full_tz_list())[0]
+        tz = "America/New_York"
 
         # Testing functionality of basic values and timezones
         dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
-        correct_timezone = self.formatter._format_token(dt, "Z")
-        assert (
-            self.formatter.format_rfc822(dt)
-            == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
-        )
+        assert self.formatter.format_rfc822(dt) == "Thu, 25 Dec 75 14:15:16 -0500"
 
         # Testing that single digit values return with a 0 in front
         dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
-        correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
         assert (
             self.formatter.format_rfc822(dt_single_digit)
-            == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+            == "Wed, 05 Feb 75 04:05:06 -0500"
         )
 
     # rfc850 format: 'Thursday, 25-Dec-75 14:15:16 EST'
     def test_rfc_850(self):
-        tz = list(make_full_tz_list())[0]
+        tz = "America/New_York"
         # Testing functionality of basic values and timezones
         dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
-        correct_timezone = self.formatter._format_token(dt, "ZZZ")
-        assert (
-            self.formatter.format_rfc850(dt)
-            == "Thursday, 25-Dec-75 14:15:16 " + correct_timezone
-        )
+        assert self.formatter.format_rfc850(dt) == "Thursday, 25-Dec-75 14:15:16 EST"
 
         # Testing that single digit values return with a 0 in front
         dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
-        correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
         assert (
             self.formatter.format_rfc850(dt_single_digit)
-            == "Wednesday, 05-Feb-75 04:05:06 " + correct_timezone
+            == "Wednesday, 05-Feb-75 04:05:06 EST"
         )
 
     #  rfc1036 format: 'Thu, 25 Dec 75 14:15:16 -0500'
     def test_rfc_1036(self):
-        tz = list(make_full_tz_list())[0]
+        tz = "America/New_York"
         # Testing functionality of basic values and timezones
         dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
-        correct_timezone = self.formatter._format_token(dt, "Z")
-        assert (
-            self.formatter.format_rfc1036(dt)
-            == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
-        )
+        assert self.formatter.format_rfc1036(dt) == "Thu, 25 Dec 75 14:15:16 -0500"
 
         # Testing that single digit values return with a 0 in front
         dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
-        correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
         assert (
             self.formatter.format_rfc1036(dt_single_digit)
-            == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+            == "Wed, 05 Feb 75 04:05:06 -0500"
         )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -211,92 +211,79 @@ class TestDateTimeFormatterPremadeFormats:
 
     # cookie format: 'Thursday, 25-Dec-1975 14:15:16 EST'
     def test_cookie(self):
-        for full_name in make_full_tz_list():
-            # Testing functionality of basic values and timezones
-            dt = datetime(
-                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt, "ZZZ")
-            assert (
-                self.formatter._format_cookie(dt)
-                == "Thursday, 25-Dec-1975 14:15:16 " + correct_timezone
-            )
+        tz = list(make_full_tz_list())[0]
+        dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
 
-            # Testing that single digit values return with a 0 in front
-            dt_single_digit = datetime(
-                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
-            assert (
-                self.formatter._format_cookie(dt_single_digit)
-                == "Wednesday, 05-Feb-1975 04:05:06 " + correct_timezone
-            )
+        correct_timezone = self.formatter._format_token(dt, "ZZZ")
+        assert (
+            self.formatter.format_cookie(dt)
+            == "Thursday, 25-Dec-1975 14:15:16 " + correct_timezone
+        )
+
+        # Testing that single digit values return with a 0 in front
+        dt_single_digit = datetime(
+            1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
+        ).replace(tzinfo=dateutil_tz.gettz(tz))
+        correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
+        assert (
+            self.formatter.format_cookie(dt_single_digit)
+            == "Wednesday, 05-Feb-1975 04:05:06 " + correct_timezone
+        )
 
     # rfc833 format: 'Thu, 25 Dec 75 14:15:16 -0500'
     def test_rfc_822(self):
-        for full_name in make_full_tz_list():
-            # Testing functionality of basic values and timezones
-            dt = datetime(
-                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt, "Z")
-            assert (
-                self.formatter._format_rfc822(dt)
-                == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
-            )
+        tz = list(make_full_tz_list())[0]
 
-            # Testing that single digit values return with a 0 in front
-            dt_single_digit = datetime(
-                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
-            assert (
-                self.formatter._format_rfc822(dt_single_digit)
-                == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
-            )
+        # Testing functionality of basic values and timezones
+        dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
+        correct_timezone = self.formatter._format_token(dt, "Z")
+        assert (
+            self.formatter.format_rfc822(dt)
+            == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
+        )
+
+        # Testing that single digit values return with a 0 in front
+        dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
+        correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
+        assert (
+            self.formatter.format_rfc822(dt_single_digit)
+            == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+        )
 
     # rfc850 format: 'Thursday, 25-Dec-75 14:15:16 EST'
     def test_rfc_850(self):
-        for full_name in make_full_tz_list():
-            # Testing functionality of basic values and timezones
-            dt = datetime(
-                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt, "ZZZ")
-            assert (
-                self.formatter._format_rfc850(dt)
-                == "Thursday, 25-Dec-75 14:15:16 " + correct_timezone
-            )
+        tz = list(make_full_tz_list())[0]
+        # Testing functionality of basic values and timezones
+        dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
+        correct_timezone = self.formatter._format_token(dt, "ZZZ")
+        assert (
+            self.formatter.format_rfc850(dt)
+            == "Thursday, 25-Dec-75 14:15:16 " + correct_timezone
+        )
 
-            # Testing that single digit values return with a 0 in front
-            dt_single_digit = datetime(
-                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
-            assert (
-                self.formatter._format_rfc850(dt_single_digit)
-                == "Wednesday, 05-Feb-75 04:05:06 " + correct_timezone
-            )
+        # Testing that single digit values return with a 0 in front
+        dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
+        correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
+        assert (
+            self.formatter.format_rfc850(dt_single_digit)
+            == "Wednesday, 05-Feb-75 04:05:06 " + correct_timezone
+        )
 
     #  rfc1036 format: 'Thu, 25 Dec 75 14:15:16 -0500'
     def test_rfc_1036(self):
-        for full_name in make_full_tz_list():
-            # Testing functionality of basic values and timezones
-            dt = datetime(
-                1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt, "Z")
-            assert (
-                self.formatter._format_rfc1036(dt)
-                == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
-            )
+        tz = list(make_full_tz_list())[0]
+        # Testing functionality of basic values and timezones
+        dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
+        correct_timezone = self.formatter._format_token(dt, "Z")
+        assert (
+            self.formatter.format_rfc1036(dt)
+            == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
+        )
 
-            # Testing that single digit values return with a 0 in front
-            dt_single_digit = datetime(
-                1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")
-            ).replace(tzinfo=dateutil_tz.gettz(full_name))
-            correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
-            assert (
-                self.formatter._format_rfc1036(dt_single_digit)
-                == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
-            )
+        # Testing that single digit values return with a 0 in front
+        dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
+        correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
+        assert (
+            self.formatter.format_rfc1036(dt_single_digit)
+            == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+        )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -258,3 +258,45 @@ class TestDateTimeFormatterPremadeFormats:
             self.formatter.format_rfc1036(dt_single_digit)
             == "Wed, 05 Feb 75 04:05:06 -0500"
         )
+
+    # rfc1123 FORMAT: 'Thu, 25 Dec 1975 14:15:16 -0500'
+    def test_rfc_1123(self):
+        tz = "America/New_York"
+        # Testing functionality of basic values and timezones
+        dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
+        assert self.formatter.format_rfc1123(dt) == "Thu, 25 Dec 1975 14:15:16 -0500"
+
+        # Testing that single digit values return with a 0 in front
+        dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
+        assert (
+            self.formatter.format_rfc1123(dt_single_digit)
+            == "Wed, 05 Feb 1975 04:05:06 -0500"
+        )
+
+    # rfc2822 format: 'Thu, 25 Dec 1975 14:15:16 -0500'
+    def test_rfc_2822(self):
+        tz = "America/New_York"
+        # Testing functionality of basic values and timezones
+        dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
+        assert self.formatter.format_rfc2822(dt) == "Thu, 25 Dec 1975 14:15:16 -0500"
+
+        # Testing that single digit values return with a 0 in front
+        dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
+        assert (
+            self.formatter.format_rfc2822(dt_single_digit)
+            == "Wed, 05 Feb 1975 04:05:06 -0500"
+        )
+
+    # rss format: 'Thu, 25 Dec 1975 14:15:16 -0500'
+    def test_rss(self):
+        tz = "America/New_York"
+        # Testing functionality of basic values and timezones
+        dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=dateutil_tz.gettz(tz))
+        assert self.formatter.format_rss(dt) == "Thu, 25 Dec 1975 14:15:16 -0500"
+
+        # Testing that single digit values return with a 0 in front
+        dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=dateutil_tz.gettz(tz))
+        assert (
+            self.formatter.format_rss(dt_single_digit)
+            == "Wed, 05 Feb 1975 04:05:06 -0500"
+        )

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytz
 from dateutil import tz as dateutil_tz
-
+from dateutil.tz import *
 from arrow import formatter
 
 from .utils import make_full_tz_list
@@ -203,3 +203,83 @@ class TestDateTimeFormatterFormatToken:
 
         # Escaping is atomic: brackets inside brackets are treated literally
         assert self.formatter.format(datetime(1, 1, 1), "[[[ ]]") == "[[ ]"
+    
+
+    # COOKIE FORMAT: 'Thursday, 25-Dec-1975 14:15:16 EST'
+    def test_cookie(self):
+        for full_name in make_full_tz_list():
+            # Testing functionality of basic values and timezones
+            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt.tzname()
+            correct_timezone = self.formatter._format_token(dt, "ZZZ")
+            assert self.formatter._format_cookie(dt) == "Thursday, 25-Dec-1975 14:15:16 " + correct_timezone
+
+            # Testing that single digit values return with a 0 in front 
+            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt_single_digit.tzname()
+            correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
+            assert self.formatter._format_cookie(dt_single_digit) == "Wednesday, 05-Feb-1975 04:05:06 " + correct_timezone
+
+
+    # rfc833 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
+    def test_rfc_822(self): 
+        for full_name in make_full_tz_list():
+            # Testing functionality of basic values and timezones
+            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt.tzname()
+            correct_timezone = self.formatter._format_token(dt, "Z")
+            assert self.formatter._format_rfc822(dt) == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
+
+            # Testing that single digit values return with a 0 in front 
+            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt_single_digit.tzname()
+            correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
+            assert self.formatter._format_rfc822(dt_single_digit) == "Wed, 05 Feb 75 04:05:06 " + correct_timezone
+    
+
+    # rfc850 FORMAT: 'Thursday, 25-Dec-75 14:15:16 EST'
+    def test_rfc_850(self): 
+        for full_name in make_full_tz_list():
+            # Testing functionality of basic values and timezones
+            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt.tzname()
+            correct_timezone = self.formatter._format_token(dt, "ZZZ")
+            assert self.formatter._format_rfc850(dt) == "Thursday, 25-Dec-75 14:15:16 " + correct_timezone
+
+            # Testing that single digit values return with a 0 in front 
+            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt_single_digit.tzname()
+            correct_timezone = self.formatter._format_token(dt_single_digit, "ZZZ")
+            assert self.formatter._format_rfc850(dt_single_digit) == "Wednesday, 05-Feb-75 04:05:06 " + correct_timezone
+    
+
+    #  rfc1036 FORMAT: 'Thu, 25 Dec 75 14:15:16 -0500'
+    def test_rfc_1036(self): 
+        for full_name in make_full_tz_list():
+            # Testing functionality of basic values and timezones
+            dt = datetime(1975, 12, 25, 14, 15, 16, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt.tzname()
+            correct_timezone = self.formatter._format_token(dt, "Z")
+            assert self.formatter._format_rfc1036(dt) == "Thu, 25 Dec 75 14:15:16 " + correct_timezone
+
+            # Testing that single digit values return with a 0 in front 
+            dt_single_digit = datetime(1975, 2, 5, 4, 5, 6, tzinfo=pytz.timezone("UTC")).replace(
+                tzinfo=dateutil_tz.gettz(full_name)
+            )
+            abbreviation = dt_single_digit.tzname()
+            correct_timezone = self.formatter._format_token(dt_single_digit, "Z")
+            assert self.formatter._format_rfc1036(dt_single_digit) == "Wed, 05 Feb 75 04:05:06 " + correct_timezone


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [X] 🧪 Added **tests** for changed code.
- [X] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [X] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

We added 4 functions to arrow/arrow/formatter.py to format a DateTime object to support cookie, rfc822, rfc850, rfc1036 formats. We added a test for each function to arrow/tests/test_formatter.py. 

This is for issue #762. We plan to continue implementing more formats based on the Pendulum documentation provided in the issue description after receiving feedback on our first 4.

@ikoningstein and I look forward to hearing your feedback.
