### PR TITLE
Fix Portuguese locale capitalization

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -1976,75 +1976,6 @@ class PortugueseLocale(Locale):
 
     month_names = [
         "",
-        "janeiro",
-        "fevereiro",
-        "março",
-        "abril",
-        "maio",
-        "junho",
-        "julho",
-        "agosto",
-        "setembro",
-        "outubro",
-        "novembro",
-        "dezembro",
-    ]
-    month_abbreviations = [
-        "",
-        "jan",
-        "fev",
-        "mar",
-        "abr",
-        "maio",
-        "jun",
-        "jul",
-        "ago",
-        "set",
-        "out",
-        "nov",
-        "dez",
-    ]
-
-    day_names = [
-        "",
-        "segunda-feira",
-        "terça-feira",
-        "quarta-feira",
-        "quinta-feira",
-        "sexta-feira",
-        "sábado",
-        "domingo",
-    ]
-    day_abbreviations = ["", "seg", "ter", "qua", "qui", "sex", "sab", "dom"]
-
-
-class BrazilianPortugueseLocale(PortugueseLocale):
-    names = ["pt_br"]
-
-    past = "faz {0}"
-
-    future = "em {0}"
-
-    timeframes = {
-        "now": "agora",
-        "second": "um segundo",
-        "seconds": "{0} segundos",
-        "minute": "um minuto",
-        "minutes": "{0} minutos",
-        "hour": "uma hora",
-        "hours": "{0} horas",
-        "day": "um dia",
-        "days": "{0} dias",
-        "week": "uma semana",
-        "weeks": "{0} semanas",
-        "month": "um mês",
-        "months": "{0} meses",
-        "year": "um ano",
-        "years": "{0} anos",
-    }
-
-    month_names = [
-        "",
         "Janeiro",
         "Fevereiro",
         "Março",
@@ -2085,6 +2016,12 @@ class BrazilianPortugueseLocale(PortugueseLocale):
         "Domingo",
     ]
     day_abbreviations = ["", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab", "Dom"]
+
+
+class BrazilianPortugueseLocale(PortugueseLocale):
+    names = ["pt_br"]
+
+    past = "faz {0}"
 
 
 class TagalogLocale(Locale):

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -882,6 +882,7 @@ class TestBrazilianPortugueseLocale:
         assert self.locale._format_timeframe("months", 11) == "11 meses"
         assert self.locale._format_timeframe("year", 1) == "um ano"
         assert self.locale._format_timeframe("years", 12) == "12 anos"
+        assert self.locale._format_relative("uma hora", "hour", -1) == "faz uma hora"
 
 
 @pytest.mark.usefixtures("lang_locale")


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [ ] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹 All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

This PR fixes the Portuguese locales values. They should essentially be the same as the Brasilian ones. Also fixed capitalization. We use month name with caps in Portugal.

Thanks.

