### PR TITLE
Fix intermittent regression test failure

### DIFF
--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1538,13 +1538,13 @@ class TestArrowHumanize:
 
         # Regression tests for humanize bug referenced in issue 541
         later = self.now.shift(days=3)
-        assert later.humanize() == "in 3 days"
+        assert later.humanize(self.now) == "in 3 days"
 
         later = self.now.shift(days=3, seconds=1)
-        assert later.humanize() == "in 3 days"
+        assert later.humanize(self.now) == "in 3 days"
 
         later = self.now.shift(days=4)
-        assert later.humanize() == "in 4 days"
+        assert later.humanize(self.now) == "in 4 days"
 
     def test_week(self):
 


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [ ] 🧪 Added **tests** for changed code.
- [ ] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹 All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [ ] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

We get very intermittent failures on our tests due to https://github.com/crsmithdev/arrow/blob/master/tests/test_arrow.py#L1539, this is my attempt to fix this.

The basic idea is that `humanize` will use `now` in whatever time zone the object calling it is in. Since `now` is always moving the result will change over time e.g.

```shell
(arrow) chris@ThinkPad:~/arrow$ python
Python 3.7.4 (default, Sep 19 2019, 11:01:37) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> arw=arrow.utcnow()
>>> three_days=arw.shift(days=3, minutes=1)
>>> three_days
<Arrow [2020-06-13T12:12:48.828483+00:00]>
>>> three_days.humanize()
'in 3 days'
#wait a few minutes
>>> three_days.humanize()
'in 2 days'
>>> three_days.humanize(arw)
'in 3 days'
```
This behaviour is expected, however if we provide our own `now` it stays consistent. My guess is that on the failing tests we are very close to a second boundary and by the time `shift` and `humanize` are called the boundary has been crossed resulting in an error.

Any thoughts guys?
 
ref #541 
