### PR TITLE
Fixed span of week issue and added tests - issue 355

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -739,7 +739,7 @@ class Arrow(object):
                 'Invalid bounds. Please select between "()", "(]", "[)", or "[]".'
             )
 
-    def span(self, frame, count=1, bounds="[)"):
+    def span(self, frame, count=1, bounds="[)", **kwargs):
         """ Returns two new :class:`Arrow <arrow.arrow.Arrow>` objects, representing the timespan
         of the :class:`Arrow <arrow.arrow.Arrow>` object in a given timeframe.
 
@@ -749,6 +749,8 @@ class Arrow(object):
             whether to include or exclude the start and end values in the span. '(' excludes
             the start, '[' includes the start, ')' excludes the end, and ']' includes the end.
             If the bounds are not specified, the default bound '[)' is used.
+        :param startSunday: (optional) if startSunday=True is specified, weekday will start on
+            Sunday instead of Monday
 
         Supported frame values: year, quarter, month, week, day, hour, minute, second.
 
@@ -793,7 +795,8 @@ class Arrow(object):
         floor = self.__class__(*values, tzinfo=self.tzinfo)
 
         if frame_absolute == "week":
-            floor = floor + relativedelta(days=-(self.isoweekday() - 1))
+            dayOfWeek = self.isoweekday(kwargs["startSunday"] if kwargs else None)
+            floor = floor + relativedelta(days=-(dayOfWeek - 1))
         elif frame_absolute == "quarter":
             floor = floor + relativedelta(months=-((self.month - 1) % 3))
 
@@ -1339,17 +1342,27 @@ class Arrow(object):
 
         return self._datetime.weekday()
 
-    def isoweekday(self):
+    def isoweekday(self, startSunday=False):
         """ Returns the ISO day of the week as an integer (1-7).
+        :param startSunday (optional): if startSunday=True is specified, weekday
+            will start on Sunday instead of Monday
 
         Usage::
 
             >>> arrow.utcnow().isoweekday()
             6
+            >>> arrow.utcnow().isoweekday(startSunday=True)
+            7
 
         """
-
-        return self._datetime.isoweekday()
+        dayOfWeek = self._datetime.isoweekday()
+        if startSunday:
+            if dayOfWeek == 7:
+                return 1
+            else:
+                return dayOfWeek + 1
+        else:
+            return dayOfWeek
 
     def isocalendar(self):
         """ Returns a 3-tuple, (ISO year, ISO week number, ISO weekday).

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -458,6 +458,24 @@ class TestArrowDatetimeInterface:
 
         assert result == self.arrow._datetime.isoweekday()
 
+    def test_isoweekday_startSunday(self):
+
+        result = self.arrow.isoweekday(startSunday=True)
+        dayOfWeek = self.arrow._datetime.isoweekday()
+
+        assert result == 1 if dayOfWeek == 7 else dayOfWeek + 1
+
+    def test_isoweekday_startSunday_edge(self):
+
+        dateSun = self.arrow.fromdatetime(datetime(2020, 6, 28))
+        dateMon = self.arrow.fromdatetime(datetime(2020, 6, 29))
+
+        resultSun = dateSun.isoweekday(startSunday=True)
+        resultMon = dateMon.isoweekday(startSunday=True)
+
+        assert resultSun == 1
+        assert resultMon == 2
+
     def test_isocalendar(self):
 
         result = self.arrow.isocalendar()
@@ -1227,6 +1245,13 @@ class TestArrowSpan:
 
         assert floor == datetime(2013, 2, 11, tzinfo=tz.tzutc())
         assert ceil == datetime(2013, 2, 17, 23, 59, 59, 999999, tzinfo=tz.tzutc())
+
+    def test_span_week_startSunday(self):
+
+        floor, ceil = self.arrow.span("week", startSunday=True)
+
+        assert floor == datetime(2013, 2, 10, tzinfo=tz.tzutc())
+        assert ceil == datetime(2013, 2, 16, 23, 59, 59, 999999, tzinfo=tz.tzutc())
 
     def test_span_day(self):
 


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets: [x] -->
- [x] 🧪 Added **tests** for changed code.
- [x] 🛠️ All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹 All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚 Updated **documentation** for changed code.
- [x] ⏩ Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

Issue #355 fixed

Changed isoweekday function in arrow.py so it takes in extra parameter startSunday, which is a bool (default false) that determines if week should start on Sunday instead of Monday.  If true, it returns (1-7) for (Sunday-Saturday) instead of (Monday-Sunday).

Changed span function to also take in startSunday parameter (via kwargs).  If startSunday is true, span will call isoweekday(True) instead of isoweekday(), so span('week') will return a week starting on Sunday and ending on Monday.

Close: #355 
