### PR TITLE
Force exact match on .get()

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -107,7 +107,7 @@ class DateTimeParser:
     )
     _ESCAPE_RE: ClassVar[Pattern[str]] = re.compile(r"\[[^\[\]]*\]")
 
-    _ONE_OR_TWO_DIGIT_RE: ClassVar[Pattern[str]] = re.compile(r"\d{1,2}")
+    _ONE_OR_TWO_DIGIT_RE: ClassVar[Pattern[str]] = re.compile(r"[1-9]\d|\d")
     _ONE_OR_TWO_OR_THREE_DIGIT_RE: ClassVar[Pattern[str]] = re.compile(r"\d{1,3}")
     _ONE_OR_MORE_DIGIT_RE: ClassVar[Pattern[str]] = re.compile(r"\d+")
     _TWO_DIGIT_RE: ClassVar[Pattern[str]] = re.compile(r"\d{2}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -147,7 +147,7 @@ class TestDateTimeParser:
 
         assert self.parser.parse(
             "15/01/2019T04:05:06.789120Z",
-            ["D/M/YYThh:mm:ss.SZ", "D/M/YYYYThh:mm:ss.SZ"],
+            ["D/MM/YYThh:mm:ss.SZ", "D/MM/YYYYThh:mm:ss.SZ"],
         ) == datetime(2019, 1, 15, 4, 5, 6, 789120, tzinfo=tz.tzutc())
 
     # regression test for issue #447

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -790,6 +790,23 @@ class TestDateTimeParserParse:
         with pytest.raises(ParserError):
             self.parser.parse("  \n Jun   1\t 2005\n ", "MMM D YYYY")
 
+    def test_parse_leading_zero(self):
+        # Regression tests for issue #1084
+        with pytest.raises(ParserError):
+            self.parser.parse("01", "M")
+
+        with pytest.raises(ParserError):
+            self.parser.parse("01", "D")
+
+        with pytest.raises(ParserError):
+            self.parser.parse("01", "H")
+
+        with pytest.raises(ParserError):
+            self.parser.parse("01", "h")
+
+        with pytest.raises(ParserError):
+            self.parser.parse("01", "s")
+
 
 @pytest.mark.usefixtures("dt_parser_regex")
 class TestDateTimeParserRegex:


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

These changes were made in collaboration with @khanm3

- Modified the _ONE_OR_TWO_DIGIT_RE regex to not accept numbers with leading zeros. This is done in order to conform to the expected behavior and throw an error when, for example, you try to match '01' with 'M'. The issue #1084 only mentions the 'M' token, but realized that the 'D', 'H', 'm', 'h', and 's' have similar behavior which we have also corrected.
- Modified an existing test case since this test was using the undesired behavior which this pull request is intended to fix
- Added a test case which checks the expected behavior for all 6 tokens.

Closes: #1084

Questions:
- We also noticed that the 'DDD' token seems to have similar behavior as well. If you try to match '001' to 'DDD', should that also be expected to fail? We left that one untouched since it uses a different regex and we weren't positive.
- Unrelated to this pull request, but we noticed that tests/test_arrow.py::TestArrowHumanize::test_months is marked as expected to fail, but before we made any changes, it was already passing. Maybe this should be updated?
