### PR TITLE
parser(fix): more robust (UTC prefix in TzInfoParser

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -734,7 +734,7 @@ class DateTimeParser:
 
 class TzinfoParser:
     _TZINFO_RE: ClassVar[Pattern[str]] = re.compile(
-        r"^(?:\(UTC)*([\+\-])?(\d{2})(?:\:?(\d{2}))?"
+        r"^(?:(\(UTC))*([\+\-])?(\d{2})(?:\:?(\d{2}))?(?(1)\)|$)"
     )
 
     @classmethod
@@ -754,7 +754,7 @@ class TzinfoParser:
                 sign: Optional[str]
                 hours: str
                 minutes: Union[str, int, None]
-                sign, hours, minutes = iso_match.groups()
+                _, sign, hours, minutes = iso_match.groups()
                 seconds = int(hours) * 3600 + int(minutes or 0) * 60
 
                 if sign == "-":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1316,9 +1316,8 @@ class TestTzinfoParser:
         assert self.parser.parse("UTC") == tz.tzutc()
 
     def test_parse_utc_withoffset(self):
-        assert self.parser.parse("(UTC+01:00") == tz.tzoffset(None, 3600)
-        assert self.parser.parse("(UTC-01:00") == tz.tzoffset(None, -3600)
-        assert self.parser.parse("(UTC+01:00") == tz.tzoffset(None, 3600)
+        assert self.parser.parse("(UTC-01:00)") == tz.tzoffset(None, -3600)
+        assert self.parser.parse("(UTC+01:00)") == tz.tzoffset(None, 3600)
         assert self.parser.parse(
             "(UTC+01:00) Amsterdam, Berlin, Bern, Rom, Stockholm, Wien"
         ) == tz.tzoffset(None, 3600)
@@ -1341,8 +1340,23 @@ class TestTzinfoParser:
         assert self.parser.parse("US/Pacific") == tz.gettz("US/Pacific")
 
     def test_parse_fails(self):
-        with pytest.raises(parser.ParserError):
-            self.parser.parse("fail")
+        pytest.raises(parser.ParserError, self.parser.parse, "fail")
+        pytest.raises(parser.ParserError, self.parser.parse, "+03:00.34")
+        pytest.raises(parser.ParserError, self.parser.parse, "+03:00 ")
+        pytest.raises(
+            parser.ParserError,
+            self.parser.parse,
+            "(UTC+01:00 Amsterdam, Berlin, Bern, Rom, Stockholm, Wien",
+        )
+        pytest.raises(
+            parser.ParserError,
+            self.parser.parse,
+            "+01:00 Amsterdam, Berlin, Bern, Rom, Stockholm, Wien",
+        )
+
+        # These get parsed by dateutil.tz.gettz(), albeit it probably shouldn't
+        # pytest.raises(parser.ParserError, self.parser.parse, "(UTC+01:00")
+        # pytest.raises(parser.ParserError, self.parser.parse, "(UTC+01:00 Amsterdam")
 
 
 @pytest.mark.usefixtures("dt_parser")


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:


- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

The changes introduced in [this PR](https://github.com/arrow-py/arrow/pull/1099) comes with unintended side effects:
It removed the end of string matching from the regex to allow for the arbitrary information at the end of the string. The intention was to match time zones like this: "(UTC+01:00) Amsterdam, Berlin, Bern, Rom, Stockholm, Wien"

This however applied to input without the "(UTC" prefix, so things like: +01:00.23 would also be handled by the code, and silently treated like "+01:00" which sounds bad. Also, misformats like this :"(UTC+01:00 Amsterdam, Berlin, Bern, Rom, Stockholm, Wien" would silently pass

The updated regex takes this into consideration, makes the closing parenthesis mandatory, and will not allow postfixes unless the string starts with the UTC prefix in parenthesis. 

## Notes
 
While this PR keeeps the original intention working, note that such timezone declarations are **not** valid in ISO (as far as I can tell without buying the standard :)), so it's a bit misleading. 

Also, after treating the special cases here the work is basically dumped to dateutil's tz, which also seem to do some strange stuff. It'll return a tzstr for monstorities like "(UTC+01:00 Amsterdam whatver else even if it is very long as long as you dont have a comma", which probably shouln't be like that, but I really did not want to stir that much into a codebase where I don't get the intentions, so for now it behaves the same way it did before these 2 PRs , but it probably could be made better :)

We've been using this to make sure user input is valid TZ, so it's a bit of a bummer.
