### PR TITLE
handle DST properly #1209

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1035,7 +1035,14 @@ class Arrow:
             relative_kwargs.pop("quarters", 0) * self._MONTHS_PER_QUARTER
         )
 
-        current = self._datetime + relativedelta(**relative_kwargs)
+        # current = self._datetime + relativedelta(**relative_kwargs)
+        original_tz = self.tzinfo
+        if self._datetime.tzinfo is not None:
+            utc_dt = self._datetime.astimezone(dateutil_tz.UTC)
+            current = utc_dt + relativedelta(**relative_kwargs)
+            current = current.astimezone(original_tz)
+        else:
+            current = self._datetime + relativedelta(**relative_kwargs)
 
         # If check_imaginary is True, perform the check for imaginary times (DST transitions)
         if check_imaginary and not dateutil_tz.datetime_exists(current):


### PR DESCRIPTION
## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

### Bug Fix
- [x] Fixed the time zone calculation error in the `shift()` method during DST transitions.
- [x] Original issue: Performing `relativedelta` operations directly on localized time caused errors during DST transition points.
- [x] New solution: Convert times with time zones to UTC for calculations, then convert them back to the original time zone.

### Code Changes
```python
# Original code (problematic code)
current = self._datetime + relativedelta(**relative_kwargs)

# Modified code (fixed code)
original_tz = self.tzinfo
if self._datetime.tzinfo is not None:
    utc_dt = self._datetime.astimezone(dateutil_tz.UTC)
    current = utc_dt + relativedelta(**relative_kwargs)
    current = current.astimezone(original_tz)
else:
    current = self._datetime + relativedelta(**relative_kwargs)

