### PR TITLE
Fix humanize reporting 'a month' for 16-day differences

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1223,8 +1223,10 @@ class Arrow:
                     calendar_diff.years * self._MONTHS_PER_YEAR + calendar_diff.months
                 )
 
-                # For months, if more than 2 weeks, count as a full month
-                if calendar_diff.days > 14:
+                # Round up partial months when already at least one
+                # calendar month has elapsed and the remaining days
+                # are more than halfway through another month.
+                if calendar_months >= 1 and calendar_diff.days > 14:
                     calendar_months += 1
 
                 calendar_months = min(calendar_months, self._MONTHS_PER_YEAR)
@@ -1236,6 +1238,13 @@ class Arrow:
                     days = sign * max(delta_second // self._SECS_PER_DAY, 2)
                     return locale.describe("days", days, only_distance=only_distance)
 
+                elif diff < self._SECS_PER_WEEK * 2 and calendar_months < 1:
+                    return locale.describe("week", sign, only_distance=only_distance)
+
+                elif calendar_months < 1 and diff < self._SECS_PER_MONTH:
+                    weeks = sign * max(delta_second // self._SECS_PER_WEEK, 2)
+                    return locale.describe("weeks", weeks, only_distance=only_distance)
+
                 elif calendar_months >= 1 and diff < self._SECS_PER_YEAR:
                     if calendar_months == 1:
                         return locale.describe(
@@ -1246,13 +1255,6 @@ class Arrow:
                         return locale.describe(
                             "months", months, only_distance=only_distance
                         )
-
-                elif diff < self._SECS_PER_WEEK * 2:
-                    return locale.describe("week", sign, only_distance=only_distance)
-
-                elif diff < self._SECS_PER_MONTH:
-                    weeks = sign * max(delta_second // self._SECS_PER_WEEK, 2)
-                    return locale.describe("weeks", weeks, only_distance=only_distance)
 
                 elif diff < self._SECS_PER_YEAR * 2:
                     return locale.describe("year", sign, only_distance=only_distance)


### PR DESCRIPTION
## Summary

Fixes #1240.

- **Bug**: `humanize` reported 16 days in the future as "in a month" instead of "in 2 weeks" because `calendar_diff.days > 14` unconditionally bumped `calendar_months` from 0 to 1, even when no calendar month boundary was crossed.
- **Fix**: Only round up partial months when `calendar_months >= 1` (an actual month boundary was crossed), and check weeks *before* months (guarded by `calendar_months < 1`) so within-month differences use the weeks granularity while true calendar-month differences (e.g., Feb 8 → Mar 8 = 28 days) still correctly show as "a month."

### Before (broken)
| Delta | Result |
|-------|--------|
| +15 days (same month) | "in 2 weeks" |
| +16 days (same month) | "in a month" |

### After (fixed)
| Delta | Result |
|-------|--------|
| +15 days (same month) | "in 2 weeks" |
| +16 days (same month) | "in 2 weeks" |
| +28 days (Feb→Mar, shift(months=1)) | "in a month" |
| +31 days (crosses month boundary) | "in a month" |

## Test plan

- [x] All 225 existing tests pass (including all 50 humanize tests)
- [x] Verified the exact scenario from the issue: Jan 9 → Jan 25 (16 days) now shows "in 2 weeks" instead of "in a month"
- [x] Verified short-month edge case: `shift(months=1)` from February (28 days) correctly shows "in a month"
- [x] Verified smooth progression: days → week → weeks → month → months