### PR TITLE
Fix humanize reporting "a year ago" for ~31-day deltas in same month

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1245,6 +1245,9 @@ class Arrow:
                     weeks = sign * max(delta_second // self._SECS_PER_WEEK, 2)
                     return locale.describe("weeks", weeks, only_distance=only_distance)
 
+                elif calendar_months < 1 and diff >= self._SECS_PER_MONTH:
+                    return locale.describe("month", sign, only_distance=only_distance)
+
                 elif calendar_months >= 1 and diff < self._SECS_PER_YEAR:
                     if calendar_months == 1:
                         return locale.describe(

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2223,6 +2223,14 @@ class TestArrowHumanize:
         assert self.now.humanize(later, only_distance=True) == "a month"
         assert later.humanize(self.now, only_distance=True) == "a month"
 
+    def test_month_boundary_with_large_delta(self):
+        """~31 days where calendar_months is 0 but elapsed exceeds _SECS_PER_MONTH."""
+        # Jan 15 -> Feb 15: calendar_months may round to 0, but 31 days > 30.5
+        arw = arrow.Arrow(2013, 1, 15)
+        later = arrow.Arrow(2013, 2, 15)
+        assert arw.humanize(later) == "a month ago"
+        assert later.humanize(arw) == "in a month"
+
     def test_months(self):
         later = self.now.shift(months=2)
         earlier = self.now.shift(months=-2)


### PR DESCRIPTION
## Summary

Fix a gap in the `humanize()` `if/elif` chain that causes `~31-day` deltas within the same calendar month to report "a year ago" instead of "a month ago".

## Problem

In the auto-granularity branch of `humanize()`, there's a gap between the "weeks" and "months" conditions:

```python
elif calendar_months < 1 and diff < self._SECS_PER_MONTH:
    # "X weeks ago"

elif calendar_months >= 1 and diff < self._SECS_PER_YEAR:
    # "X months ago"

elif diff < self._SECS_PER_YEAR * 2:
    # "a year ago"
```

When `diff >= _SECS_PER_MONTH` (30.5 days) **and** `calendar_months < 1` (both dates in the same calendar month), neither the "weeks" nor the "months" condition is satisfied:
- "weeks" requires `diff < _SECS_PER_MONTH` → **False**
- "months" requires `calendar_months >= 1` → **False**

Execution falls through to the "a year ago" branch.

### Reproduction

```python
import arrow

start = arrow.Arrow(2023, 1, 1)
end = arrow.Arrow(2023, 1, 31, 14, 0, 0)  # 30.5+ days later, same month

start.humanize(end)  # Returns "a year ago" instead of "a month ago"
```

This affects all 7 months with 31 days (January, March, May, July, August, October, December) when comparing timestamps near the boundaries of the same month.

## Fix

Add an explicit branch for this case: when `calendar_months < 1` but `diff >= _SECS_PER_MONTH`, report the delta as "a month".
