### PR TITLE
Fix _TIMESTAMP_RE to match single-digit timestamps

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -166,7 +166,7 @@ class DateTimeParser:
     _TZ_NAME_RE: ClassVar[Pattern[str]] = re.compile(r"\w[\w+\-/]+")
     # NOTE: timestamps cannot be parsed from natural language strings (by removing the ^...$) because it will
     # break cases like "15 Jul 2000" and a format list (see issue #447)
-    _TIMESTAMP_RE: ClassVar[Pattern[str]] = re.compile(r"^\-?\d+\.?\d+$")
+    _TIMESTAMP_RE: ClassVar[Pattern[str]] = re.compile(r"^\-?\d+\.?\d*$")
     _TIMESTAMP_EXPANDED_RE: ClassVar[Pattern[str]] = re.compile(r"^\-?\d+$")
     _TIME_RE: ClassVar[Pattern[str]] = re.compile(
         r"^(\d{2})(?:\:?(\d{2}))?(?:\:?(\d{2}))?(?:([\.\,])(\d+))?$"


### PR DESCRIPTION
## Summary

Fix `_TIMESTAMP_RE` to correctly match single-digit timestamps like epoch `0`.

## Problem

The current regex pattern is:
```python
_TIMESTAMP_RE = re.compile(r"^\-?\d+\.?\d+$")
```

This requires `\d+` (one or more digits) on **both** sides of the optional decimal point. For single-digit values:
1. `\d+` greedily matches the only digit
2. `\.?` optionally matches nothing
3. `\d+` requires at least one more digit, but input is exhausted → no match

```python
import re
pattern = re.compile(r"^\-?\d+\.?\d+$")
pattern.match("0")       # None  ← should match
pattern.match("1")       # None  ← should match
pattern.match("-1")      # None  ← should match
pattern.match("10")      # Match ← works for 2+ digits
```

This means `arrow.get("0", "X")` raises `ParserMatchError` instead of parsing epoch 0.

## Fix

Change the trailing `\d+` to `\d*` so the fractional part is fully optional:
```python
_TIMESTAMP_RE = re.compile(r"^\-?\d+\.?\d*$")
```
