### PR TITLE
Fix Italian locale plural seconds timeframe

### DIFF
--- a/arrow/locales.py
+++ b/arrow/locales.py
@@ -411,7 +411,7 @@ class ItalianLocale(Locale):
     timeframes = {
         "now": "adesso",
         "second": "un secondo",
-        "seconds": "{0} qualche secondo",
+        "seconds": "{0} secondi",
         "minute": "un minuto",
         "minutes": "{0} minuti",
         "hour": "un'ora",


### PR DESCRIPTION
## Summary

Fix the Italian locale's `"seconds"` timeframe to use the correct plural form.

## Problem

The `"seconds"` timeframe in `ItalianLocale` is:
```python
"seconds": "{0} qualche secondo",
```

"qualche secondo" means "a few seconds" / "some seconds" in Italian. When the `{0}` placeholder is substituted with a number, the output is grammatically wrong:

```
"15 qualche secondo fa"  → "15 some second ago" (nonsensical)
```

Other timeframes in the same locale use correct plural forms:
- `"minutes": "{0} minuti"` ✓
- `"hours": "{0} ore"` ✓
- `"days": "{0} giorni"` ✓

## Fix

Change to `"{0} secondi"` which is the standard Italian plural:
```
"15 secondi fa"  → "15 seconds ago" ✓
```
