### PR TITLE
docs: add microsecond to supported frame values in span/interval/range/span_range; fix interval example typo

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -424,7 +424,7 @@ class Arrow(object):
             the start, '[' includes the start, ')' excludes the end, and ']' includes the end.
             If the bounds are not specified, the default bound '[)' is used.
 
-        Supported frame values: year, quarter, month, week, day, hour, minute, second
+        Supported frame values: year, quarter, month, week, day, hour, minute, second, microsecond.
 
         Recognized datetime expressions:
 
@@ -447,7 +447,7 @@ class Arrow(object):
             ...
             (<Arrow [2013-05-05T12:00:00+00:00]>, <Arrow [2013-05-05T13:59:59.999999+00:00]>)
             (<Arrow [2013-05-05T14:00:00+00:00]>, <Arrow [2013-05-05T15:59:59.999999+00:00]>)
-            (<Arrow [2013-05-05T16:00:00+00:00]>, <Arrow [2013-05-05T17:59:59.999999+00:0]>)
+            (<Arrow [2013-05-05T16:00:00+00:00]>, <Arrow [2013-05-05T17:59:59.999999+00:00]>)
         """
         if interval < 1:
             raise ValueError("interval has to be a positive integer")
@@ -750,7 +750,7 @@ class Arrow(object):
             the start, '[' includes the start, ')' excludes the end, and ']' includes the end.
             If the bounds are not specified, the default bound '[)' is used.
 
-        Supported frame values: year, quarter, month, week, day, hour, minute, second.
+        Supported frame values: year, quarter, month, week, day, hour, minute, second, microsecond.
 
         Usage::
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -302,7 +302,7 @@ class Arrow(object):
         iterating.  As such, either call with naive objects and ``tz``, or aware objects from the
         same timezone and no ``tz``.
 
-        Supported frame values: year, quarter, month, week, day, hour, minute, second.
+        Supported frame values: year, quarter, month, week, day, hour, minute, second, microsecond.
 
         Recognized datetime expressions:
 
@@ -378,7 +378,7 @@ class Arrow(object):
         iterating.  As such, either call with naive objects and ``tz``, or aware objects from the
         same timezone and no ``tz``.
 
-        Supported frame values: year, quarter, month, week, day, hour, minute, second.
+        Supported frame values: year, quarter, month, week, day, hour, minute, second, microsecond.
 
         Recognized datetime expressions:
 


### PR DESCRIPTION
Found a few small documentation inconsistencies while reading through the docstrings.

The `microsecond` frame is fully supported by `_get_frames()` - it's right there in `_T_FRAMES` and in the error message the method raises when you pass something invalid. But four docstrings list the supported frames as `"year, quarter, month, week, day, hour, minute, second"` without `microsecond`. You can verify it works: `arrow.utcnow().span('microsecond')` returns a valid tuple, no complaints. The typed overloads of `range()` and `span_range()` already had it listed correctly, which made the inconsistency extra confusing - it's the untyped versions and `span()`/`interval()` that were wrong.

Also caught a typo in the `interval()` usage example: the last line of output had `+00:0]>` instead of `+00:00]>` - one zero snuck off somewhere.

Fixes:
- `span()`: added `microsecond` to "Supported frame values"
- `interval()`: added `microsecond` + the missing trailing period
- untyped `range()` and `span_range()` overloads: same fix for consistency
- `interval()` example output: `+00:0]>` ? `+00:00]>`