### PR TITLE
Fix MAX_TIMESTAMP calculation to use UTC timezone

### DIFF
--- a/arrow/constants.py
+++ b/arrow/constants.py
@@ -1,7 +1,7 @@
 """Constants used internally in arrow."""
 
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Final
 
 # datetime.max.timestamp() errors on Windows, so we must hardcode
@@ -11,7 +11,7 @@ from typing import Final
 try:
     # Get max timestamp. Works on POSIX-based systems like Linux and macOS,
     # but will trigger an OverflowError, ValueError, or OSError on Windows
-    _MAX_TIMESTAMP = datetime.max.timestamp()
+    _MAX_TIMESTAMP = datetime.max.replace(tzinfo=timezone.utc).timestamp()
 except (OverflowError, ValueError, OSError):  # pragma: no cover
     # Fallback for Windows and 32-bit systems if initial max timestamp call fails
     # Must get max value of ctime on Windows based on architecture (x32 vs x64)
@@ -19,9 +19,9 @@ except (OverflowError, ValueError, OSError):  # pragma: no cover
     # Note: this may occur on both 32-bit Linux systems (issue #930) along with Windows systems
     is_64bits = sys.maxsize > 2**32
     _MAX_TIMESTAMP = (
-        datetime(3000, 1, 1, 23, 59, 59, 999999).timestamp()
+        datetime(3000, 1, 1, 23, 59, 59, 999999, tzinfo=timezone.utc).timestamp()
         if is_64bits
-        else datetime(2038, 1, 1, 23, 59, 59, 999999).timestamp()
+        else datetime(2038, 1, 1, 23, 59, 59, 999999, tzinfo=timezone.utc).timestamp()
     )
 
 MAX_TIMESTAMP: Final[float] = _MAX_TIMESTAMP

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -3097,3 +3097,17 @@ class TestArrowUtil:
 
         with pytest.raises(ValueError):
             arrow.Arrow._get_iteration_params(None, None)
+
+
+class TestArrowConstants:
+    def test_max_timestamp_is_utc_based(self):
+        from arrow.constants import MAX_TIMESTAMP
+
+        expected = datetime.max.replace(tzinfo=timezone.utc).timestamp()
+        assert MAX_TIMESTAMP == expected
+
+    def test_max_timestamp_derived_constants(self):
+        from arrow.constants import MAX_TIMESTAMP, MAX_TIMESTAMP_MS, MAX_TIMESTAMP_US
+
+        assert MAX_TIMESTAMP_MS == MAX_TIMESTAMP * 1000
+        assert MAX_TIMESTAMP_US == MAX_TIMESTAMP * 1_000_000

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from arrow import util
+from arrow import constants, util
 
 
 class TestUtil:
@@ -121,6 +121,14 @@ class TestUtil:
         assert util.normalize_timestamp(timestamp) == timestamp
         assert util.normalize_timestamp(millisecond_timestamp) == 1591161115.194
         assert util.normalize_timestamp(microsecond_timestamp) == 1591161115.194556
+
+        # GH #1159: a valid second-precision timestamp near datetime.max must be
+        # left untouched, regardless of the host's local time zone. Previously the
+        # constant collapsed to a year-3000 fallback on non-UTC hosts, so this value
+        # exceeded MAX_TIMESTAMP and was wrongly rescaled as ms -> a 1978 datetime.
+        max_year_timestamp = 253402214400.0  # arrow.get("9999-12-31").timestamp()
+        assert max_year_timestamp <= constants.MAX_TIMESTAMP
+        assert util.normalize_timestamp(max_year_timestamp) == max_year_timestamp
 
         with pytest.raises(ValueError):
             util.normalize_timestamp(3e17)


### PR DESCRIPTION
## Pull Request Checklist

- [x] 🧪  Added **tests** for changed code.
- [x] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [x] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

Closes: #1095
Closes: #1159

`MAX_TIMESTAMP` in `arrow/constants.py` is calculated using `datetime.max.timestamp()`, which interprets the naive datetime as local time. This means the resulting timestamp varies depending on the system's local timezone, leading to inconsistent behavior across different environments.

This PR fixes the issue by explicitly setting the timezone to UTC before calling `.timestamp()`:

```python
# Before (timezone-dependent)
_MAX_TIMESTAMP = datetime.max.timestamp()

# After (always UTC)
_MAX_TIMESTAMP = datetime.max.replace(tzinfo=timezone.utc).timestamp()
```

The same fix is applied to the Windows/32-bit fallback values to ensure consistency across all platforms.

**Tests added:**
- `test_max_timestamp_is_utc_based` — verifies `MAX_TIMESTAMP` equals the UTC-based calculation
- `test_max_timestamp_derived_constants` — verifies `MAX_TIMESTAMP_MS` and `MAX_TIMESTAMP_US` are correctly derived

All 1905 tests pass with 99.93% coverage.