### PR TITLE
Fix dehumanize() silently ignoring negative time values

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1380,6 +1380,18 @@ class Arrow:
 
         current_time = self.fromdatetime(self._datetime)
 
+        # Reject negative time values early.  The number-extraction regex
+        # (\d+) only matches unsigned digits, so an input like "in -1 hours"
+        # would silently drop the minus sign and return the *opposite*
+        # direction.  Raising here gives the caller a clear message instead
+        # of a quietly wrong result.
+        if re.search(r"(?:^|\s)-\d", input_string):
+            raise ValueError(
+                f"Negative time values are not supported in dehumanize "
+                f"(got {input_string!r}). "
+                f"Use a positive value with 'ago' or 'in' to indicate direction."
+            )
+
         # Create an object containing the relative time info
         time_object_info = dict.fromkeys(
             ["seconds", "minutes", "hours", "days", "weeks", "months", "years"], 0

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2987,6 +2987,33 @@ class TestArrowDehumanize:
                 assert arw.dehumanize(past_string, locale=lang) == past
                 assert arw.dehumanize(future_string, locale=lang) == future
 
+    def test_negative_values(self):
+        arw = arrow.Arrow(2000, 6, 18, 5, 55, 0)
+
+        # Negative time values should raise ValueError instead of
+        # silently dropping the sign and returning a wrong result.
+        # See: https://github.com/arrow-py/arrow/issues/1278
+        negative_inputs = [
+            "in -1 hours",
+            "in -2 days",
+            "-3 minutes ago",
+            "in -30 seconds",
+        ]
+
+        for s in negative_inputs:
+            with pytest.raises(ValueError, match="Negative time values"):
+                arw.dehumanize(s)
+
+        # Positive time values should continue to succeed
+        assert arw.dehumanize("in 1 hours") == arw.shift(hours=1)
+        assert arw.dehumanize("2 days ago") == arw.shift(days=-2)
+
+        # Hyphenated strings without spaces preceding the minus/hyphen should not
+        # trigger the negative validation error (they will raise ValueError for unrecognized units).
+        with pytest.raises(ValueError) as excinfo:
+            arw.dehumanize("some-2nd-hour")
+        assert "Negative time values" not in str(excinfo.value)
+
 
 class TestArrowIsBetween:
     def test_start_before_end(self):


### PR DESCRIPTION
Fixes #1278 
## Problem

`dehumanize("in -1 hours")` silently returns the same result as `dehumanize("in 1 hours")` - it drops the minus sign without any warning.

I ran into this while building a scheduling tool that accepts relative time strings from users. A typo like `"in -2 days"` would silently schedule something 2 days *ahead* instead of raising an error, which took me a while to track down.

### Root cause

The number-extraction regex in `dehumanize()` uses `\d+` to match the numeric value from the input. Since `\d` only matches `[0-9]`, the minus sign in `-1` is never captured - the regex matches `1` and moves on. The sign information is completely lost.

### Before this fix

```python
>>> now = arrow.now()
>>> r1 = now.dehumanize("in 1 hours")
>>> r2 = now.dehumanize("in -1 hours")
>>> (r1 - now).total_seconds()
3600.0
>>> (r2 - now).total_seconds()
3600.0  # <- wrong, same as positive!
```

### After this fix

```python
>>> now.dehumanize("in -1 hours")
ValueError: Negative time values are not supported in dehumanize
(got 'in -1 hours'). Use a positive value with 'ago' or 'in' to
indicate direction.
```

## Changes

- **`arrow/arrow.py`**: Added an early check in `dehumanize()` that detects negative numbers (`-\d` pattern) in the input string and raises a `ValueError` with a clear message, before the regex-based parsing begins.
- - **`tests/test_arrow.py`**: Added `test_negative_values` to verify that inputs like `"in -1 hours"`, `"in -2 days"`, `"-3 minutes ago"`, and `"in -30 seconds"` all raise `ValueError`.
All existing dehumanize tests continue to pass.