### PR TITLE
fix: handle IndexError on malformed format strings in parser

### DIFF
--- a/arrow/parser.py
+++ b/arrow/parser.py
@@ -422,12 +422,17 @@ class DateTimeParser:
         parts: _Parts = {}
         for token in fmt_tokens:
             value: Union[Tuple[str, str, str], str]
-            if token == "Do":
-                value = match.group("value")
-            elif token == "W":
-                value = (match.group("year"), match.group("week"), match.group("day"))
-            else:
-                value = match.group(token)
+            try:
+                if token == "Do":
+                    value = match.group("value")
+                elif token == "W":
+                    value = (match.group("year"), match.group("week"), match.group("day"))
+                else:
+                    value = match.group(token)
+            except IndexError:
+                raise ParserMatchError(
+                    f"Failed to match {fmt!r} when parsing {datetime_string!r}."
+                )
 
             if value is None:
                 raise ParserMatchError(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -779,6 +779,15 @@ class TestDateTimeParserParse:
         with pytest.raises(ParserError):
             self.parser.parse("  \n Jun   1\t 2005\n ", "MMM D YYYY")
 
+    def test_parse_malformed_fmt_no_indexerror(self):
+        """Malformed format strings should raise ParserMatchError, not IndexError."""
+        with pytest.raises(ParserMatchError):
+            self.parser.parse(
+                "foo",
+                "[-FFFFFFFFFFFFFFFFFFFFF-[-FFFFFFFFFFFF"
+                "[ |||||||| 7   v.dG(dG\\][3zasks  &",
+            )
+
 
 @pytest.mark.usefixtures("dt_parser_regex")
 class TestDateTimeParserRegex:


### PR DESCRIPTION
- Catch IndexError during token group extraction and raise ParserMatchError instead.
- Add test case for malformed format strings lacking expected regex named groups.
- Fixes #1191

## Pull Request Checklist

Thank you for taking the time to improve Arrow! Before submitting your pull request, please check all *appropriate* boxes:

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [ ] 🧪  Added **tests** for changed code.
- [ ] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [ ] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [ ] ⏩  Code is **up-to-date** with the `master` branch.

If you have *any* questions about your code changes or any of the points above, please submit your questions along with the pull request and we will try our best to help!

## Description of Changes

<!--
Replace this commented text block with a description of your code changes.

If your PR has an associated issue, insert the issue number (e.g. #703) or directly link to the GitHub issue (e.g. https://github.com/arrow-py/arrow/issues/703).

Pro-tip: writing "Closes: #703" in the PR body will automatically close issue #703 when the PR is merged.
-->
