### PR TITLE
reject negative numeric values in dehumanize with a clear ValueError

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1378,6 +1378,16 @@ class Arrow:
                 f"Dehumanize does not currently support the {locale} locale, please consider making a contribution to add support for this locale."
             )
 
+        # Reject inputs that contain a negative integer literal. Humanized time
+        # strings use locale-defined "ago"/"in" markers for direction, so a
+        # leading "-N" sign is almost certainly a user error and would
+        # otherwise be silently dropped by the \d+ number matcher.
+        if re.search(r"-\d+", input_string):
+            raise ValueError(
+                "Dehumanize does not support negative numeric values; "
+                "use the locale's past/future marker to indicate direction."
+            )
+
         current_time = self.fromdatetime(self._datetime)
 
         # Create an object containing the relative time info

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2960,6 +2960,35 @@ class TestArrowDehumanize:
                 assert arw.dehumanize(past_string, locale=lang) == past
                 assert arw.dehumanize(future_string, locale=lang) == future
 
+    def test_negative_numeric_value_raises(self):
+        # Regression for arrow-py/arrow#1278: the internal number-extraction
+        # regex matched unsigned digits only, so "in -1 hours" silently dropped
+        # the sign and produced the same result as "in 1 hours". Surface a
+        # ValueError instead of producing a wrong datetime.
+        arw = arrow.Arrow(2025, 1, 1, 12, 0, 0)
+
+        for bad in (
+            "in -1 hours",
+            "in -2 days",
+            "-3 minutes ago",
+            "in -1.5 hours",
+            "-2 days",
+            "in  -7 seconds",  # internal whitespace doesn't change sign
+        ):
+            with pytest.raises(ValueError, match="negative"):
+                arw.dehumanize(bad)
+
+    def test_negative_value_check_does_not_break_positive_inputs(self):
+        # The negative-value guard must not affect normally-formatted
+        # humanized strings. Sample a few representative cases.
+        arw = arrow.Arrow(2025, 6, 1, 9, 30, 0)
+
+        assert arw.dehumanize("in 3 hours") == arw.shift(hours=3)
+        assert arw.dehumanize("in 2 days") == arw.shift(days=2)
+        assert arw.dehumanize("3 hours ago") == arw.shift(hours=-3)
+        assert arw.dehumanize("2 days ago") == arw.shift(days=-2)
+        assert arw.dehumanize("in 15 minutes") == arw.shift(minutes=15)
+
     def test_czech_slovak(self):
         # Relevant units for Slavic locale plural logic
         units = [


### PR DESCRIPTION
Fixes arrow-py/arrow#1278.

## Problem

The internal number-extraction regex in `dehumanize()` is `\d+`, which matches unsigned digits only. An input like `in -1 hours` was silently truncated to `1`, so `dehumanize('in -1 hours')` and `dehumanize('in 1 hours')` returned the exact same Arrow — opposite to what a user typing `-1` almost certainly meant.



## Fix

Add a single guard at the top of `dehumanize`:



Humanized time strings are directional via the locale's past/future markers (`ago`, `in`, `vor`, `hace`, `il y a`, ...), so a leading `-N` is always a sign of user error. The error message points the caller at the right fix.

## Tests

`tests/test_arrow.py`:

- `test_negative_numeric_value_raises` — parametrized over six malformed inputs (`in -1 hours`, `in -2 days`, `-3 minutes ago`, `in -1.5 hours`, `-2 days`, `in  -7 seconds`) all raising `ValueError` with a message containing `negative`.
- `test_negative_value_check_does_not_break_positive_inputs` — five sanity round-trips (`in 3 hours`, `in 2 days`, `3 hours ago`, `2 days ago`, `in 15 minutes`) to confirm the guard doesn't regress normal usage.

## Verification

```
python3 -m pytest tests/  # 1906 passed, 1 skipped
ruff check arrow/arrow.py tests/test_arrow.py  # all checks passed
black --check arrow/arrow.py tests/test_arrow.py  # 2 files would be left unchanged
isort --check arrow/arrow.py tests/test_arrow.py  # clean
```