### PR TITLE
Fix `is_between()` reporting wrong type in end date error message

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1525,7 +1525,7 @@ class Arrow:
             )
 
         if not isinstance(end, Arrow):
-            raise TypeError(f"Cannot parse end date argument type of {type(start)!r}.")
+            raise TypeError(f"Cannot parse end date argument type of {type(end)!r}.")
 
         include_start = bounds[0] == "["
         include_end = bounds[1] == "]"

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -3047,6 +3047,22 @@ class TestArrowIsBetween:
         with pytest.raises(TypeError):
             target.is_between(None, None)
 
+    def test_type_error_exception_message(self):
+        target = arrow.Arrow.fromdatetime(datetime(2013, 5, 7))
+        end = arrow.Arrow.fromdatetime(datetime(2013, 5, 8))
+        start = datetime(2013, 5, 5)
+        with pytest.raises(
+            TypeError, match="start date argument type of <class 'datetime.datetime'>"
+        ):
+            target.is_between(start, end)
+
+        start = arrow.Arrow.fromdatetime(datetime(2013, 5, 5))
+        end = datetime(2013, 5, 8)
+        with pytest.raises(
+            TypeError, match="end date argument type of <class 'datetime.datetime'>"
+        ):
+            target.is_between(start, end)
+
     def test_value_error_exception(self):
         target = arrow.Arrow.fromdatetime(datetime(2013, 5, 7))
         start = arrow.Arrow.fromdatetime(datetime(2013, 5, 5))


### PR DESCRIPTION
## Pull Request Checklist

<!-- Check boxes by placing an x in the brackets like this: [x] -->
- [X] 🧪  Added **tests** for changed code.
- [X] 🛠️  All tests **pass** when run locally (run `tox` or `make test` to find out!).
- [x] 🧹  All linting checks **pass** when run locally (run `tox -e lint` or `make lint` to find out!).
- [ ] 📚  Updated **documentation** for changed code.
- [X] ⏩  Code is **up-to-date** with the `master` branch.

## Description of Changes

`is_between()` used `type(start)` instead of `type(end)` in the error message when `end` is invalid.
