### PR TITLE
dehumanize: reject negative quantities so in -1 hours does not silently match in 1 hours

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1394,6 +1394,20 @@ class Arrow:
         # Create a regex pattern object for numbers
         num_pattern = re.compile(r"\d+")
 
+        # Detect a negative integer anywhere in the input. dehumanize uses
+        # ago/in for direction, so a literal '-' in front of a digit (e.g.
+        # 'in -1 hours' or '-2 days ago') is a sign of user error: the
+        # magnitude-only num_pattern below would silently drop it and the
+        # caller would get a datetime offset in the wrong direction.
+        # '2 days ago - 1 hour' and other arithmetic-style strings are
+        # out of scope (they don't match the locale timeframes anyway).
+        if re.search(r"-\d+", input_string):
+            raise ValueError(
+                f"Dehumanize string {input_string!r} contains a negative number; "
+                "use 'ago' / 'in' (or the equivalent locale word) to express "
+                "direction instead of a leading minus sign."
+            )
+
         # Search input string for each time unit within locale
         for unit, unit_object in locale_obj.timeframes.items():
             # Need to check the type of unit_object to create the correct dictionary

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -2930,6 +2930,22 @@ class TestArrowDehumanize:
             with pytest.raises(ValueError):
                 arw.dehumanize(empty_future_string, locale=lang)
 
+    def test_dehumanize_rejects_negative_numbers(self) -> None:
+        # dehumanize parses the input via a \d+-only regex, so a leading minus
+        # sign on the quantity was silently dropped, making "in -1 hours" and
+        # "in 1 hours" return the same result. Direction is expressed by the
+        # "ago" / "in" word, so a negative number is always a user error.
+        arw = arrow.Arrow(2025, 1, 1, 12, 0, 0)
+        negative_inputs = [
+            "in -1 hours",
+            "in -2 days",
+            "-3 minutes ago",
+            "-1 year",
+        ]
+        for bad_input in negative_inputs:
+            with pytest.raises(ValueError, match="negative number"):
+                arw.dehumanize(bad_input)
+
     def test_slavic_locales(self, slavic_locales: List[str]):
         # Relevant units for Slavic locale plural logic
         units = [


### PR DESCRIPTION
Closes https://github.com/arrow-py/arrow/issues/1278.

`Arrow.dehumanize` parses the input via an `r"\d+"` regex to find the quantity for each time unit. The regex matches unsigned digits only, so a leading minus sign on the quantity is dropped:

    >>> import arrow
    >>> now = arrow.now()
    >>> (now.dehumanize("in 1 hours") - now).total_seconds()
    3600.0
    >>> (now.dehumanize("in -1 hours") - now).total_seconds()
    3600.0  # should be -3600.0, but the minus is silently dropped

Direction is expressed by the "in" / "ago" word, so a negative number is always a user error.

Fix: scan the input for a leading minus sign on a numeric token (matching `-\s*\d+`) and raise `ValueError("dehumanize string contains a negative number; use 'ago' / 'in' (or the equivalent locale word) to express direction instead of a leading minus sign")` if one is found. The check runs after the locale validation but before the per-unit regex matching so the failure mode is uniform regardless of which locale is in use.

New test `test_dehumanize_rejects_negative_numbers` in `tests/test_arrow.py` parametrized over `"in -1 hours"`, `"in -2 days"`, `"-3 minutes ago"`, `"-1 year"`. All four raise `ValueError` matching `"negative number"` with the fix; on the pre-fix code they all silently produce the wrong magnitude. Pre-existing dehumanize tests (22) still pass.
