### PR TITLE
is_between: name the offending type of the end argument, not the start argument

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1525,7 +1525,7 @@ class Arrow:
             )
 
         if not isinstance(end, Arrow):
-            raise TypeError(f"Cannot parse end date argument type of {type(start)!r}.")
+            raise TypeError(f"Cannot parse end date argument type of {type(end)!r}.")
 
         include_start = bounds[0] == "["
         include_end = bounds[1] == "]"

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -3047,6 +3047,16 @@ class TestArrowIsBetween:
         with pytest.raises(TypeError):
             target.is_between(None, None)
 
+    def test_is_between_error_message_mentions_end_type(self):
+        target = arrow.Arrow.fromdatetime(datetime(2013, 5, 7))
+        start = arrow.Arrow.fromdatetime(datetime(2013, 5, 5))
+        end = datetime(2013, 5, 8)
+        with pytest.raises(TypeError) as excinfo:
+            target.is_between(start, end)
+        assert "end" in str(excinfo.value)
+        assert "datetime" in str(excinfo.value)
+        assert "Arrow" not in str(excinfo.value)
+
     def test_value_error_exception(self):
         target = arrow.Arrow.fromdatetime(datetime(2013, 5, 7))
         start = arrow.Arrow.fromdatetime(datetime(2013, 5, 5))


### PR DESCRIPTION
### What

`Arrow.is_between` raises a `TypeError` when `start` or `end` is not an `Arrow` instance. The check for `end` formats the error message using `type(start)` instead of `type(end)`, so the message misleads the user when only `end` is wrong.

### Why

The first `TypeError` for `start` correctly names the offending type (the user passed something that wasn't an `Arrow`). The second `TypeError` for `end` was a copy-paste that re-uses `type(start)` — so if `start` is a perfectly valid `Arrow` and the user passes a `datetime` as `end`, the error says `Cannot parse end date argument type of <class 'arrow.arrow.Arrow'>.`, which is confusing.

### Fix

Use `type(end)` in the second error message so it accurately describes the offending argument.

### Tests

Added `test_is_between_error_message_mentions_end_type` to `tests/test_arrow.py::TestArrowIsBetween` that passes a `datetime` for `end` and asserts the error message mentions `end` and `datetime` and does not mention `Arrow`. All 226 tests in `tests/test_arrow.py` pass.